### PR TITLE
Removed time penalties from regular event-reader operation.

### DIFF
--- a/lib/events-reader.js
+++ b/lib/events-reader.js
@@ -189,10 +189,10 @@ module.exports = function (harvesterApp) {
                         });
 
                 } else {
-                    that.reschedule(1000);
+                    that.reschedule(0);
                 }
             } else {
-                that.reschedule(1000);
+                that.reschedule(0);
             }
         };
 


### PR DESCRIPTION
tests run fine (and much faster) with this change on both fuse and harvesterjs.