### PR TITLE
Feature/event reader filters updates

### DIFF
--- a/lib/events-reader.js
+++ b/lib/events-reader.js
@@ -116,6 +116,38 @@ module.exports = function (harvesterApp) {
 
                         var dfd = RSVP.defer();
 
+                        function checkFilterExecuteHandler(id, dfd, opFn, changeHandlerOp, doc) {
+                            var filter = 'o.$set.' + opFn.filter;
+
+                            debug('filtering on ' + filter);
+
+                            var test = _.has(doc, filter, false);
+
+                            debug('filter exists ' + test);
+
+                            if (test) {
+                                return executeHandler(id, dfd, opFn.func, changeHandlerOp, doc);
+                            }
+
+                            return;
+                        }
+
+                        function executeHandler(id, dfd, opFn, changeHandlerOp, doc) {
+                            debug('processing resource op ' + changeHandlerOp);
+
+                            new RSVP.Promise(function (resolve, reject) {
+                                resolve(opFn(id));
+                            })
+                            .then(function () {
+                                dfd.resolve(doc);
+                            })
+                            .catch(function (err) {
+                                console.trace(err);
+                                debug('onChange handler raised an error, retrying in 500ms.');
+                                setTimeout(processWithHandler, 500, doc);
+                            });
+                        }
+
                         function processWithHandler(doc) {
 
                             var op = doc.op;
@@ -131,19 +163,11 @@ module.exports = function (harvesterApp) {
 
                                 var changeHandlerOp = opMap[op];
                                 var opFn = changeHandler[changeHandlerOp];
-                                if (opFn) {
-                                    debug('processing resource op ' + changeHandlerOp);
-                                    new RSVP.Promise(function (resolve, reject) {
-                                        resolve(opFn(id));
-                                    })
-                                        .then(function () {
-                                            dfd.resolve(doc);
-                                        })
-                                        .catch(function (err) {
-                                            console.trace(err);
-                                            debug('onChange handler raised an error, retrying in 500ms.');
-                                            setTimeout(processWithHandler, 500, doc);
-                                        });
+
+                                if (_.isFunction(opFn)) {
+                                    executeHandler(id, dfd, opFn, changeHandlerOp, doc);
+                                } else if (opFn && typeof(opFn.func) === "function") {
+                                    checkFilterExecuteHandler(id, dfd, opFn, changeHandlerOp, doc);
                                 } else {
                                     that.skip(dfd, doc)
                                 }


### PR DESCRIPTION
So this change allows you to do the following to a model, as you can see we no longer pass in a `function` to `onChange` we pass in an `object` that contains a `function` and a `filter`.  Harvester will check to see if that property has changed, and only execute it if so.  By default, `onChange` will accept a `function`, so no further change is required, and we don't break backward compatability.

This is a first stab at it so would appreciate your feedback.

```
fortuneApp.resource('tracker', {
    deviceId: String
})
}).onChange({
    update: { func : sendToTopcon("update", fortuneApp, counter), filter : 'equipment' }
});
```