### PR TITLE
GetLinkedIds didn’t return anything in the case where the final resou…

### DIFF
--- a/lib/includes.js
+++ b/lib/includes.js
@@ -152,6 +152,8 @@ module.exports = function (adapter, schemas) {
                 } else {
                     return _.union(acc, [id]);
                 }
+            }else{
+                return acc;
             }
         }, []);
     }


### PR DESCRIPTION
…rce traversed by the _.reduce didn’t have resource.links && resource.links[path], which meant that we’d lose everything that should have been included.