### PR TITLE
Implement Roles in harvester 2.0

### DIFF
--- a/lib/harvester.js
+++ b/lib/harvester.js
@@ -113,7 +113,7 @@ Harvester.prototype._init = function (options) {
 
   this.changeHandlers = {};
 
-    route.getRestMethods().forEach(function (httpMethod) {
+    route.getRouteMethodNames().forEach(function (httpMethod) {
         harvesterInstance[httpMethod] = function () {
             var resource = harvesterInstance.createdResources[harvesterInstance._resource];
             return resource[httpMethod].apply(resource);
@@ -309,37 +309,59 @@ Harvester.prototype.after = function (name, fn) {
   return this;
 };
 
+/**
+ * Export map of all defined roles and it's permissions.
+ *
+ * @returns {{}} map or roles and permissions, i.e. {Admin:['person.getById','person.putById'], Moderator: ['person.get', 'user.post']}
+ */
 Harvester.prototype.exportRoles = function () {
     var roles = {};
+    /**
+     * For each resource get all it's rest method (endpoint) and check if there are roles assigned directly to that rest method.
+     * If yes, then for each such role assign permission to that rest method;
+     * otherwise for each role defined on resource assign permission to that rest method.
+     */
     _.forEach(this.createdResources, function (resource) {
-        _.forEach(resource.roles, function (role) {
-            roles[role] = roles[role] || [];
-            route.getRestMethods().forEach(function (httpMethod) {
-                if (resource[httpMethod]().options.notAllowed) {
-                        return;
-                    }
-                    var methodRoles = resource[httpMethod]().roles;
-                    var permission = resource[httpMethod]().getPermission();
-                    if (_.isEmpty(methodRoles)) {
-                        roles[role].push(permission);
-                    } else {
-                        _.forEach(methodRoles, function (role) {
-                            roles[role] = roles[role] || [];
-                            roles[role].push(permission);
-                        })
-                    }
+        route.getRouteMethodNames().forEach(function (restMethodName) {
+            var restMethod = resource[restMethodName]();
+            if (restMethod.options.notAllowed) {
+                return;
+            }
+            var methodRoles = restMethod.roles;
+            var permission = restMethod.getPermissionName();
+            if (!_.isEmpty(methodRoles)) {
+                /*If roles are NOT defined on method level, then for each role defined on resource assign permission to that rest method;*/
+                _.forEach(methodRoles, function (role) {
+                    roles[role] = roles[role] || [];
+                    roles[role].push(permission);
                 });
-        })
+            } else {
+                /*If roles are defined on method level, then for each such role assign permission to that rest method;*/
+                _.forEach(resource.roles, function (role) {
+                    roles[role] = roles[role] || [];
+                    roles[role].push(permission);
+                });
+            }
+        });
     });
+    /**
+     * Remove duplicates
+     */
     _.forEach(roles, function (permissions, role) {
         roles[role] = _.uniq(permissions);
     });
     return roles;
 };
 
+/**
+ * Set roles allowed to access most recently defined/referenced resource.
+ *
+ * i.e. harvesterApp.resource('person').roles('Admin', 'Moderator');
+ *
+ * @returns {this}
+ */
 Harvester.prototype.roles = function () {
-    var roles = Array.prototype.slice.call(arguments);
-    this.createdResources[this._resource].roles = roles;
+    this.createdResources[this._resource].roles = Array.prototype.slice.call(arguments);
     return this;
 };
 

--- a/lib/harvester.js
+++ b/lib/harvester.js
@@ -9,14 +9,13 @@ var inflect = require('i')();
 var Adapter = require('./adapter');
 var route = require('./route');
 
-var createdRoutes = {};
 var sendError = require('./send-error');
 
 /*!
  * The Harvester object.
  */
 function Harvester () {
-  this._init.apply(this, arguments);
+    this._init.apply(this, arguments);
 }
 
 /**
@@ -86,15 +85,15 @@ Harvester.prototype._defaults = {
  * @param {Object} options
  */
 Harvester.prototype._init = function (options) {
-  var router;
+    var router, harvesterInstance = this;
 
-  // Initialize options.
-  options = typeof options === 'object' ? options : {};
-  for(var key in this._defaults) {
-    if (!options.hasOwnProperty(key)) {
-      options[key] = this._defaults[key];
+    // Initialize options.
+    options = typeof options === 'object' ? options : {};
+    for (var key in this._defaults) {
+        if (!options.hasOwnProperty(key)) {
+            options[key] = this._defaults[key];
+        }
     }
-  }
   this.options = options;
 
   // Create the underlying express framework instance.
@@ -113,6 +112,13 @@ Harvester.prototype._init = function (options) {
   this.adapter = new Adapter(options);
 
   this.changeHandlers = {};
+
+    route.getRestMethods().forEach(function (httpMethod) {
+        harvesterInstance[httpMethod] = function () {
+            var resource = harvesterInstance.createdResources[harvesterInstance._resource];
+            return resource[httpMethod].apply(resource);
+        }
+    });
 
 };
 
@@ -182,17 +188,10 @@ Harvester.prototype.resource = function (name, resourceSchema, options) {
   this.changeHandlers[name] = [];
 
   var mongooseSchema = _this.adapter.schema(name, processedLegacySchema, options);
-  createdRoutes[name]=_this._route(name, _this.adapter.model(name, mongooseSchema), _.clone(resourceSchema), options);
+    this.createdResources = this.createdResources || {};
+    this.createdResources[name] = new route(_this, name, _this.adapter.model(name, mongooseSchema), _.clone(resourceSchema), options);
 
-['get', 'post', 'put', 'delete', 'patch', 'getById', 'putById', 'deleteById', 'patchById', 'getChangeEventsStreaming'].forEach(function(httpMethod) {
-
-  this[httpMethod] = function() {
-    var resource = createdRoutes[this._resource];
-    return resource[httpMethod].apply(resource);
-  }
-});
-
-  return this;
+    return this;
 };
 
 /**
@@ -308,6 +307,40 @@ Harvester.prototype.before = function (name, fn) {
 Harvester.prototype.after = function (name, fn) {
   this._addTransform(name, fn, '_after');
   return this;
+};
+
+Harvester.prototype.exportRoles = function () {
+    var roles = {};
+    _.forEach(this.createdResources, function (resource) {
+        _.forEach(resource.roles, function (role) {
+            roles[role] = roles[role] || [];
+            route.getRestMethods().forEach(function (httpMethod) {
+                if (resource[httpMethod]().options.notAllowed) {
+                        return;
+                    }
+                    var methodRoles = resource[httpMethod]().roles;
+                    var permission = resource[httpMethod]().getPermission();
+                    if (_.isEmpty(methodRoles)) {
+                        roles[role].push(permission);
+                    } else {
+                        _.forEach(methodRoles, function (role) {
+                            roles[role] = roles[role] || [];
+                            roles[role].push(permission);
+                        })
+                    }
+                });
+        })
+    });
+    _.forEach(roles, function (permissions, role) {
+        roles[role] = _.uniq(permissions);
+    });
+    return roles;
+};
+
+Harvester.prototype.roles = function () {
+    var roles = Array.prototype.slice.call(arguments);
+    this.createdResources[this._resource].roles = roles;
+    return this;
 };
 
 /**
@@ -473,14 +506,6 @@ Harvester.prototype._before = {};
  * @api private
  */
 Harvester.prototype._after = {};
-
-/**
- * Method to route a resource.
- *
- * @api private
- */
-Harvester.prototype._route = route;
-Harvester.prototype.route = route;
 
 /**
  * Keep track of the last added resource so that we can

--- a/lib/route.js
+++ b/lib/route.js
@@ -3,6 +3,7 @@ var _ = require('lodash');
 var inflect = require('i')();
 var SSE = require('./sse');
 var RouteMethod = require('./route.method.js');
+var sendError = require('./send-error');
 // constants
 var MIME = {
     standard: ['application/vnd.api+json', 'application/json'],
@@ -17,19 +18,25 @@ var Joi = require('joi');
 /**
  * Setup routes for a resource, given a name and model.
  *
+ * @param {Object} harvester
  * @param {String} name
  * @param {Object} model
+ * @param {Object} schema
+ * @param {Object} routeOptions
  */
-function route(name, model, schema, routeOptions) {
-    var _this = this;
-    var router = this.router;
-    var adapter = this.adapter;
+function route(harvester, name, model, schema, routeOptions) {
 
-    this._oplogEnabled = !!this.options.oplogConnectionString;
-    this._oplogEnabled && SSE.init(this.router, this.adapter, this.options);
+    var _this = this;
+    var router = harvester.router;
+    var adapter = harvester.adapter;
+
+    this.name = name;
+
+    this._oplogEnabled = !!harvester.options.oplogConnectionString;
+    this._oplogEnabled && SSE.init(router, adapter, harvester.options);
 
     // options
-    var options = this.options;
+    var options = harvester.options;
     routeOptions = routeOptions || {};
     var resourceNamespace = routeOptions.namespace;
     var namespace = resourceNamespace ? options.namespace + '/' + resourceNamespace : options.namespace;
@@ -47,89 +54,95 @@ function route(name, model, schema, routeOptions) {
     //v2 route
 
     this.get = new RouteMethod({
-        resourceName: name,
-        harvester: _this,
+        resource: _this,
+        harvester: harvester,
         handlers : this.fnHandlers,
         method : 'get',
-        route : collectionRoute
+        route: collectionRoute,
+        permissionSuffix: 'get'
     });
 
     this.post = new RouteMethod({
-        resourceName: name,
-        harvester: _this,
+        resource: _this,
+        harvester: harvester,
         handlers : this.fnHandlers,
         method : 'post',
-        route : collectionRoute
+        route: collectionRoute,
+        permissionSuffix: 'post'
     });
 
     this.put = new RouteMethod({
-        resourceName: name,
-        harvester: _this,
+        resource: _this,
+        harvester: harvester,
         method : 'put',
         route : collectionRoute,
         notAllowed : true
     });
 
     this.delete = new RouteMethod({
-        resourceName: name,
-        harvester: _this,
+        resource: _this,
+        harvester: harvester,
         method : 'delete',
         route : collectionRoute,
         notAllowed : true
     });
 
     this.patch = new RouteMethod({
-        resourceName: name,
-        harvester: _this,
+        resource: _this,
+        harvester: harvester,
         method : 'patch',
         route : collectionRoute,
         notAllowed : true
     });
 
     this.getById = new RouteMethod({
-        resourceName: name,
-        harvester: _this,
+        resource: _this,
+        harvester: harvester,
         handlers : this.fnHandlers,
         method : 'get',
-        route : individualRoute
+        route: individualRoute,
+        permissionSuffix: 'getById'
     });
 
     this.putById = new RouteMethod({
-        resourceName: name,
-        harvester: _this,
+        resource: _this,
+        harvester: harvester,
         handlers : this.fnHandlers,
         method : 'put',
-        route : individualRoute
+        route: individualRoute,
+        permissionSuffix: 'putById'
     });
 
     this.deleteById = new RouteMethod({
-        resourceName: name,
-        harvester: _this,
+        resource: _this,
+        harvester: harvester,
         handlers : this.fnHandlers,
         method : 'delete',
-        route : individualRoute
+        route: individualRoute,
+        permissionSuffix: 'deleteById'
     });
 
     this.patchById = new RouteMethod({
-        resourceName: name,
-        harvester: _this,
+        resource: _this,
+        harvester: harvester,
         handlers : this.fnHandlers,
         method : 'patch',
-        route: individualRoute
+        route: individualRoute,
+        permissionSuffix: 'patchById'
     });
 
     this.getChangeEventsStreaming = new RouteMethod({
-        resourceName: name,
-        harvester: _this,
+        resource: _this,
+        harvester: harvester,
         handlers : this.fnHandlers,
         method : 'get',
         route : collectionRoute,
-        sse : true
+        sse: true,
+        permissionSuffix: 'getChangeEventsStreaming'
     });
 
     // response emitters
     // todo handle array of errors in sendError
-    var sendError = require('./send-error');
 
     var sendResponse = function (req, res, status, object) {
         if (status === 204) return res.send(status);
@@ -182,8 +195,10 @@ function route(name, model, schema, routeOptions) {
             model = name;
         }
         return new Promise(function (resolve, reject) {
-            if (!_this._before.hasOwnProperty(model)) return resolve(resource);
-            var transform = _this._before[model].call(resource, request, response);
+            if (!harvester._before.hasOwnProperty(model)) {
+                return resolve(resource);
+            }
+            var transform = harvester._before[model].call(resource, request, response);
             if (!transform) return reject();
             resolve(transform);
         });
@@ -205,8 +220,10 @@ function route(name, model, schema, routeOptions) {
             model = name;
         }
         return new Promise(function (resolve, reject) {
-            if (!_this._after.hasOwnProperty(model)) return resolve(resource);
-            var transform = _this._after[model].call(resource, request, response);
+            if (!harvester._after.hasOwnProperty(model)) {
+                return resolve(resource);
+            }
+            var transform = harvester._after[model].call(resource, request, response);
             if (!transform) return reject();
             resolve(transform);
         });
@@ -285,11 +302,9 @@ function route(name, model, schema, routeOptions) {
                         types.push(key);
                         linkedResources = linkedResources.map(function (resource) {
                             // find out which resources are linked to by this collection
-                            var associations = _.filter(
-                                getAssociations.call(_this, _this._schema[singularKey]),
-                                function (association) {
-                                    return association.type === collection;
-                                });
+                            var associations = _.filter(getAssociations(harvester._schema[singularKey], harvester.options), function (association) {
+                                return association.type === collection;
+                            });
                             // Supports adding links to the primary resource on the linked resources
                             associations.forEach(function (association) {
                                 resource.links = resource.links || {};
@@ -559,7 +574,7 @@ function route(name, model, schema, routeOptions) {
 
                 ids = resource.links[key];
                 ids = _.isArray(ids) ? ids : [ids];
-                relatedModel = _this._schema[name][key];
+                relatedModel = harvester._schema[name][key];
                 relatedModel = _.isArray(relatedModel) ? relatedModel[0] : relatedModel;
                 relatedModel = _.isPlainObject(relatedModel) ? relatedModel.ref : relatedModel;
 
@@ -793,8 +808,7 @@ function route(name, model, schema, routeOptions) {
     }
 
     function findResources(type, ids) {
-        var adapter = this.adapter,
-            model = adapter.model(inflect.singularize(type));
+        var model = adapter.model(inflect.singularize(type));
         return adapter.findMany(model, ids);
     }
 
@@ -840,7 +854,7 @@ function route(name, model, schema, routeOptions) {
                                 body.linked[result.type] = body.linked[result.type] || [];
                                 body.linked[result.type] = body.linked[result.type].concat(result.resources);
                             }
-                            return fetchChildren(context, fetchedIds, body, config[key], result.resources, _this._schema[inflect.singularize(result.type)], req, res);
+                            return fetchChildren(context, fetchedIds, body, config[key], result.resources, harvester._schema[inflect.singularize(result.type)], req, res);
                         }
                     });
             }
@@ -857,7 +871,7 @@ function route(name, model, schema, routeOptions) {
      */
 
     function appendLinked(body, inclusions, req, res) {
-        var schemas = this._schema;
+        var schemas = harvester._schema;
         var _this = this;
         var promises = [];
 
@@ -906,8 +920,8 @@ function route(name, model, schema, routeOptions) {
      */
 
     function appendLinkForKey(body, key) {
-        var schema = _this._schema[options.inflect ? inflect.singularize(key) : key];
-        var associations = getAssociations.call(_this, schema);
+        var schema = harvester._schema[options.inflect ? inflect.singularize(key) : key];
+        var associations = getAssociations(schema, options);
 
         if (!associations.length) return;
         body.links = body.links || {};
@@ -924,9 +938,6 @@ function route(name, model, schema, routeOptions) {
     }
 
     function appendLinks(body) {
-        var _this = this;
-        var options = this.options;
-
         _.each(body, function (value, key) {
             if (key === 'meta') return;
             if (key === "linked") {
@@ -951,9 +962,8 @@ function route(name, model, schema, routeOptions) {
  * @param {Object} schema
  * @return {Array}
  */
-function getAssociations(schema) {
+function getAssociations(schema, options) {
     var associations = [];
-    var options = this.options;
 
     _.each(schema, function (value, key) {
         var singular = !_.isArray(value);
@@ -970,6 +980,9 @@ function getAssociations(schema) {
     return associations;
 }
 
+route.getRestMethods = function () {
+    return ['get', 'post', 'put', 'delete', 'patch', 'getById', 'putById', 'deleteById', 'patchById', 'getChangeEventsStreaming'];
+};
 
 /*
  * Expose the route method.

--- a/lib/route.js
+++ b/lib/route.js
@@ -302,9 +302,11 @@ function route(harvester, name, model, schema, routeOptions) {
                         types.push(key);
                         linkedResources = linkedResources.map(function (resource) {
                             // find out which resources are linked to by this collection
-                            var associations = _.filter(getAssociations(harvester._schema[singularKey], harvester.options), function (association) {
-                                return association.type === collection;
-                            });
+                            var associations = _.filter(
+                                getAssociations(harvester._schema[singularKey], harvester.options),
+                                function (association) {
+                                    return association.type === collection;
+                                });
                             // Supports adding links to the primary resource on the linked resources
                             associations.forEach(function (association) {
                                 resource.links = resource.links || {};
@@ -980,7 +982,7 @@ function getAssociations(schema, options) {
     return associations;
 }
 
-route.getRestMethods = function () {
+route.getRouteMethodNames = function () {
     return ['get', 'post', 'put', 'delete', 'patch', 'getById', 'putById', 'deleteById', 'patchById', 'getChangeEventsStreaming'];
 };
 

--- a/lib/route.method.js
+++ b/lib/route.method.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var Promise = require('bluebird');
 
 var SSE = require('./sse');
@@ -30,7 +31,10 @@ function createRouteInterceptor(routeMethod) {
         }
 
         function isAuthorizationRequired() {
-            return authorizationStrategy instanceof Function && routeMethod.authorizationRequired !== false;
+            var isMethodNotAllowed = methodNotAllowed === routeMethod.handlerFunc;
+            var authorizationEnabled = routeMethod.authorizationRequired !== false;
+            var authorizationStrategyPresent = authorizationStrategy instanceof Function;
+            return authorizationEnabled && !isMethodNotAllowed && authorizationStrategyPresent;
         }
 
         /**
@@ -59,7 +63,9 @@ function createRouteInterceptor(routeMethod) {
         }
 
         if (isAuthorizationRequired()) {
-            handleAuthorizationResult(authorizationStrategy(request, routeMethod.getPermission()));
+            var rolesAllowed = _.isEmpty(routeMethod.roles) ? routeMethod.options.resource.roles : routeMethod.roles;
+            var authorizationResult = authorizationStrategy(request, routeMethod.getPermission(), rolesAllowed || []);
+            handleAuthorizationResult(authorizationResult);
         } else {
             callRouteHandler();
         }
@@ -70,8 +76,8 @@ function RouteMethod(options) {
     if (options.harvester == null) {
         throw new Error('Options must include reference to harvester (property harvester)');
     }
-    if (options.resourceName == null) {
-        throw new Error('Options must include resource name (property resourceName)');
+    if (options.resource == null) {
+        throw new Error('Options must include resource (property resource)');
     }
     this.options = options;
     this.authorizationRequired = true;
@@ -125,12 +131,17 @@ RouteMethod.prototype.handler = function () {
 };
 
 RouteMethod.prototype.getPermission = function () {
-    return this.options.resourceName + '.' + this.options.method;
+    return this.options.resource.name + '.' + (this.options.permissionSuffix || this.options.method);
 };
 
-RouteMethod.prototype.validate = function(validateFunc) {
-  this.validateFunc = validateFunc;
-  return this;
+RouteMethod.prototype.validate = function (validateFunc) {
+    this.validateFunc = validateFunc;
+    return this;
+};
+
+RouteMethod.prototype.roles = function () {
+    this.roles = Array.prototype.slice.call(arguments);
+    return this;
 };
 
 module.exports = RouteMethod;

--- a/lib/route.method.js
+++ b/lib/route.method.js
@@ -5,7 +5,7 @@ var SSE = require('./sse');
 var JSONAPI_Error = require('./jsonapi-error.js');
 var sendError = require('./send-error');
 
-function methodNotAllowed(req, res) {
+function methodNotAllowedFunc(req, res) {
     sendError(req, res, new JSONAPI_Error({status: 405}));
 }
 
@@ -31,10 +31,10 @@ function createRouteInterceptor(routeMethod) {
         }
 
         function isAuthorizationRequired() {
-            var isMethodNotAllowed = methodNotAllowed === routeMethod.handlerFunc;
-            var authorizationEnabled = routeMethod.authorizationRequired !== false;
-            var authorizationStrategyPresent = authorizationStrategy instanceof Function;
-            return authorizationEnabled && !isMethodNotAllowed && authorizationStrategyPresent;
+            var methodNotAllowed = (methodNotAllowedFunc === routeMethod.handlerFunc);
+            var authorizationEnabled = (routeMethod.authorizationRequired !== false);
+            var authorizationStrategyPresent = (authorizationStrategy instanceof Function);
+            return authorizationEnabled && !methodNotAllowed && authorizationStrategyPresent;
         }
 
         /**
@@ -64,7 +64,7 @@ function createRouteInterceptor(routeMethod) {
 
         if (isAuthorizationRequired()) {
             var rolesAllowed = _.isEmpty(routeMethod.roles) ? routeMethod.options.resource.roles : routeMethod.roles;
-            var authorizationResult = authorizationStrategy(request, routeMethod.getPermission(), rolesAllowed || []);
+            var authorizationResult = authorizationStrategy(request, routeMethod.getPermissionName(), rolesAllowed || []);
             handleAuthorizationResult(authorizationResult);
         } else {
             callRouteHandler();
@@ -102,8 +102,8 @@ RouteMethod.prototype.register = function () {
     }
 
     if (this.options.notAllowed) {
-        this.handlerFunc = methodNotAllowed;
-        this.options.harvester.router[method](route, methodNotAllowed);
+        this.handlerFunc = methodNotAllowedFunc;
+        this.options.harvester.router[method](route, methodNotAllowedFunc);
     } else {
         this.handlerFunc = handlers[route][method];
         this.options.harvester.router[method](this.options.route, createRouteInterceptor(thatRouteMethod));
@@ -130,7 +130,7 @@ RouteMethod.prototype.handler = function () {
     return this.handlerFunc;
 };
 
-RouteMethod.prototype.getPermission = function () {
+RouteMethod.prototype.getPermissionName = function () {
     return this.options.resource.name + '.' + (this.options.permissionSuffix || this.options.method);
 };
 

--- a/lib/send-error.js
+++ b/lib/send-error.js
@@ -50,8 +50,9 @@ var sendError = function (req, res, error) {
             // see: https://docs.npmjs.com/misc/coding-style for more info.
 
             // log error if it's a 500 or strange error
-            if (!(error instanceof JSONAPI_Error) || (error instanceof JSONAPI_Error && error.error.status > 500))
-                console.trace(error);
+            if (!(error instanceof JSONAPI_Error) || (error instanceof JSONAPI_Error && error.error.status > 500)) {
+                console.trace(error && error.stack || error);
+            }
 
             // add normalised error to the list
             errorList.push(normaliseError(error).error);

--- a/test/roles.spec.js
+++ b/test/roles.spec.js
@@ -1,0 +1,377 @@
+var Promise = require('bluebird');
+var request = require('supertest');
+var Joi = require('joi');
+
+var harvester = require('../lib/harvester');
+var seeder = require('./seeder.js');
+var config = require('./config.js');
+
+describe('Roles', function () {
+
+    var harvesterInstance;
+    var harvesterPort = 8008;
+    var seedingHarvesterPort = harvesterPort + 1;
+    var baseUrl = 'http://localhost:' + harvesterPort;
+    var seedingBaseUrl = 'http://localhost:' + seedingHarvesterPort;
+    var personId = '11111111-1111-1111-1111-111111111111';
+    var userId = '22222222-2222-2222-2222-222222222222';
+    var petId = '33333333-3333-3333-3333-333333333333';
+    var authorizationStrategy;
+
+    before(function () {
+        harvesterInstance = harvester(config.harvester.options);
+        var resourceSchema = {name: Joi.string()};
+        harvesterInstance.resource('person', resourceSchema).roles('Admin');
+        harvesterInstance.resource('pets', resourceSchema);
+        harvesterInstance.resource('user', resourceSchema).roles('Admin', 'SuperAdmin');
+        harvesterInstance.resource('user').getById().roles('Moderator');
+        harvesterInstance.setAuthorizationStrategy(function () {
+            return authorizationStrategy.apply(this, arguments);
+        });
+        harvesterInstance.listen(harvesterPort);
+
+        /**
+         * We need separate instance that does not have roles authorization, so that we can seed freely.
+         */
+        var seedingHarvesterInstance = harvester(config.harvester.options);
+        seedingHarvesterInstance.resource('person', resourceSchema);
+        seedingHarvesterInstance.resource('pets', resourceSchema);
+        seedingHarvesterInstance.resource('user', resourceSchema);
+        seedingHarvesterInstance.listen(harvesterPort + 1);
+        this.seedingHarvesterInstance = seedingHarvesterInstance;
+    });
+    beforeEach(function () {
+        var seederInstance = seeder(this.seedingHarvesterInstance, seedingBaseUrl);
+        return seederInstance.dropCollections('people', 'pets', 'users').then(function () {
+            return seederInstance.seedCustomFixture({people: [
+                {id: personId, name: 'Jack'}
+            ], users: [
+                {id: userId, name: 'Jill'}
+            ], pets: [
+                {id: petId, name: 'JillDog'}
+            ]});
+        });
+    });
+
+    describe('having specific config, exportRoles', function () {
+        it('should return proper roles descriptor', function () {
+            var expectedDescriptor = {
+                Admin: ['person.get', 'person.post', 'person.getById', 'person.putById', 'person.deleteById', 'person.patchById',
+                        'person.getChangeEventsStreaming', 'user.get', 'user.post', 'user.putById', 'user.deleteById', 'user.patchById',
+                        'user.getChangeEventsStreaming'],
+                SuperAdmin: ['user.get', 'user.post', 'user.putById', 'user.deleteById', 'user.patchById', 'user.getChangeEventsStreaming'],
+                Moderator: ['user.getById']
+            };
+            harvesterInstance.exportRoles().should.eql(expectedDescriptor);
+        });
+    });
+
+    describe('being authed as Admin', function () {
+        beforeEach(function () {
+            authorizationStrategy = function (request, permission, rolesAllowed) {
+                if (rolesAllowed.length === 0 || -1 < rolesAllowed.indexOf(('Admin'))) {
+                    return Promise.resolve();
+                } else {
+                    return Promise.reject();
+                }
+            }
+        });
+        it('should be allowed to get people', function (done) {
+            request(baseUrl).get('/people').expect(200).end(done);
+        });
+        it('should be allowed to post person', function (done) {
+            request(baseUrl).post('/people').send({people: [
+                {name: 'Steve'}
+            ]}).expect(201).end(done);
+        });
+        it('should be allowed to get person by id', function (done) {
+            request(baseUrl).get('/people/' + personId).expect(200).end(done);
+        });
+        it('should be allowed to put person by id', function (done) {
+            request(baseUrl).put('/people/' + personId).send({people: [
+                {name: 'Joseph'}
+            ]}).expect(200).end(done);
+        });
+        it('should be allowed to patch person by id', function (done) {
+            var patch = [
+                {
+                    op: 'replace',
+                    path: '/people/0/name',
+                    value: 'Josephine'
+                }
+            ];
+            request(baseUrl).patch('/people/' + personId).send(patch).expect(200).end(done);
+        });
+        it.skip('should be allowed to getChangeEventsStreaming for person', function () {
+            throw new Error('Not implemented yet');
+        });
+
+
+        it('should be allowed to get users', function (done) {
+            request(baseUrl).get('/users').expect(200).end(done);
+        });
+        it('should be allowed to post user', function (done) {
+            request(baseUrl).post('/users').send({users: [
+                {name: 'Steve'}
+            ]}).expect(201).end(done);
+        });
+        it('should NOT be allowed to get user by id', function (done) {
+            request(baseUrl).get('/users/' + userId).expect(403).end(done);
+        });
+        it('should be allowed to put user by id', function (done) {
+            request(baseUrl).put('/users/' + userId).send({users: [
+                {name: 'Joseph'}
+            ]}).expect(200).end(done);
+        });
+        it('should be allowed to patch user by id', function (done) {
+            var patch = [
+                {
+                    op: 'replace',
+                    path: '/users/0/name',
+                    value: 'Josephine'
+                }
+            ];
+            request(baseUrl).patch('/users/' + userId).send(patch).expect(200).end(done);
+        });
+        it.skip('should be allowed to getChangeEventsStreaming for user', function () {
+            throw new Error('Not implemented yet');
+        });
+
+
+        it('should be allowed to get pets', function (done) {
+            request(baseUrl).get('/pets').expect(200).end(done);
+        });
+        it('should be allowed to post pet', function (done) {
+            request(baseUrl).post('/pets').send({pets: [
+                {name: 'Steve'}
+            ]}).expect(201).end(done);
+        });
+        it('should be allowed to get pet by id', function (done) {
+            request(baseUrl).get('/pets/' + petId).expect(200).end(done);
+        });
+        it('should be allowed to put pet by id', function (done) {
+            request(baseUrl).put('/pets/' + petId).send({pets: [
+                {name: 'Joseph'}
+            ]}).expect(200).end(done);
+        });
+        it('should be allowed to patch pet by id', function (done) {
+            var patch = [
+                {
+                    op: 'replace',
+                    path: '/pets/0/name',
+                    value: 'Josephine'
+                }
+            ];
+            request(baseUrl).patch('/pets/' + petId).send(patch).expect(200).end(done);
+        });
+        it.skip('should be allowed to getChangeEventsStreaming for pet', function () {
+            throw new Error('Not implemented yet');
+        });
+    });
+
+    describe('being authed as SuperAdmin', function () {
+        beforeEach(function () {
+            authorizationStrategy = function (request, permission, rolesAllowed) {
+                if (rolesAllowed.length === 0 || -1 < rolesAllowed.indexOf(('SuperAdmin'))) {
+                    return Promise.resolve();
+                } else {
+                    return Promise.reject();
+                }
+            }
+        });
+        it('should NOT be allowed to get people', function (done) {
+            request(baseUrl).get('/people').expect(403).end(done);
+        });
+        it('should NOT be allowed to post person', function (done) {
+            request(baseUrl).post('/people').send({people: [
+                {name: 'Steve'}
+            ]}).expect(403).end(done);
+        });
+        it('should NOT be allowed to get person by id', function (done) {
+            request(baseUrl).get('/people/' + personId).expect(403).end(done);
+        });
+        it('should NOT be allowed to put person by id', function (done) {
+            request(baseUrl).put('/people/' + personId).send({people: [
+                {name: 'Joseph'}
+            ]}).expect(403).end(done);
+        });
+        it('should NOT be allowed to patch person by id', function (done) {
+            var patch = [
+                {
+                    op: 'replace',
+                    path: '/people/0/name',
+                    value: 'Josephine'
+                }
+            ];
+            request(baseUrl).patch('/people/' + personId).send(patch).expect(403).end(done);
+        });
+        it.skip('should NOT be allowed to getChangeEventsStreaming for person', function () {
+            throw new Error('Not implemented yet');
+        });
+
+
+        it('should be allowed to get users', function (done) {
+            request(baseUrl).get('/users').expect(200).end(done);
+        });
+        it('should be allowed to post user', function (done) {
+            request(baseUrl).post('/users').send({users: [
+                {name: 'Steve'}
+            ]}).expect(201).end(done);
+        });
+        it('should NOT be allowed to get user by id', function (done) {
+            request(baseUrl).get('/users/' + userId).expect(403).end(done);
+        });
+        it('should be allowed to put user by id', function (done) {
+            request(baseUrl).put('/users/' + userId).send({users: [
+                {name: 'Joseph'}
+            ]}).expect(200).end(done);
+        });
+        it('should be allowed to patch user by id', function (done) {
+            var patch = [
+                {
+                    op: 'replace',
+                    path: '/users/0/name',
+                    value: 'Josephine'
+                }
+            ];
+            request(baseUrl).patch('/users/' + userId).send(patch).expect(200).end(done);
+        });
+        it.skip('should be allowed to getChangeEventsStreaming for user', function () {
+            throw new Error('Not implemented yet');
+        });
+
+
+        it('should be allowed to get pets', function (done) {
+            request(baseUrl).get('/pets').expect(200).end(done);
+        });
+        it('should be allowed to post pet', function (done) {
+            request(baseUrl).post('/pets').send({pets: [
+                {name: 'Steve'}
+            ]}).expect(201).end(done);
+        });
+        it('should be allowed to get pet by id', function (done) {
+            request(baseUrl).get('/pets/' + petId).expect(200).end(done);
+        });
+        it('should be allowed to put pet by id', function (done) {
+            request(baseUrl).put('/pets/' + petId).send({pets: [
+                {name: 'Joseph'}
+            ]}).expect(200).end(done);
+        });
+        it('should be allowed to patch pet by id', function (done) {
+            var patch = [
+                {
+                    op: 'replace',
+                    path: '/pets/0/name',
+                    value: 'Josephine'
+                }
+            ];
+            request(baseUrl).patch('/pets/' + petId).send(patch).expect(200).end(done);
+        });
+        it.skip('should be allowed to getChangeEventsStreaming for pet', function () {
+            throw new Error('Not implemented yet');
+        });
+    });
+
+    describe('being authed as Moderator', function () {
+        beforeEach(function () {
+            authorizationStrategy = function (request, permission, rolesAllowed) {
+                if (rolesAllowed.length === 0 || -1 < rolesAllowed.indexOf(('Moderator'))) {
+                    return Promise.resolve();
+                } else {
+                    return Promise.reject();
+                }
+            }
+        });
+        it('should NOT be allowed to get people', function (done) {
+            request(baseUrl).get('/people').expect(403).end(done);
+        });
+        it('should NOT be allowed to post person', function (done) {
+            request(baseUrl).post('/people').send({people: [
+                {name: 'Steve'}
+            ]}).expect(403).end(done);
+        });
+        it('should NOT be allowed to get person by id', function (done) {
+            request(baseUrl).get('/people/' + personId).expect(403).end(done);
+        });
+        it('should NOT be allowed to put person by id', function (done) {
+            request(baseUrl).put('/people/' + personId).send({people: [
+                {name: 'Joseph'}
+            ]}).expect(403).end(done);
+        });
+        it('should NOT be allowed to patch person by id', function (done) {
+            var patch = [
+                {
+                    op: 'replace',
+                    path: '/people/0/name',
+                    value: 'Josephine'
+                }
+            ];
+            request(baseUrl).patch('/people/' + personId).send(patch).expect(403).end(done);
+        });
+        it.skip('should NOT be allowed to getChangeEventsStreaming for person', function () {
+            throw new Error('Not implemented yet');
+        });
+
+
+        it('should NOT be allowed to get users', function (done) {
+            request(baseUrl).get('/users').expect(403).end(done);
+        });
+        it('should NOT be allowed to post user', function (done) {
+            request(baseUrl).post('/users').send({users: [
+                {name: 'Steve'}
+            ]}).expect(403).end(done);
+        });
+        it('should be allowed to get user by id', function (done) {
+            request(baseUrl).get('/users/' + userId).expect(200).end(done);
+        });
+        it('should NOT be allowed to put user by id', function (done) {
+            request(baseUrl).put('/users/' + userId).send({users: [
+                {name: 'Joseph'}
+            ]}).expect(403).end(done);
+        });
+        it('should NOT be allowed to patch user by id', function (done) {
+            var patch = [
+                {
+                    op: 'replace',
+                    path: '/users/0/name',
+                    value: 'Josephine'
+                }
+            ];
+            request(baseUrl).patch('/users/' + userId).send(patch).expect(403).end(done);
+        });
+        it.skip('should NOT be allowed to getChangeEventsStreaming for user', function () {
+            throw new Error('Not implemented yet');
+        });
+
+
+        it('should be allowed to get pets', function (done) {
+            request(baseUrl).get('/pets').expect(200).end(done);
+        });
+        it('should be allowed to post pet', function (done) {
+            request(baseUrl).post('/pets').send({pets: [
+                {name: 'Steve'}
+            ]}).expect(201).end(done);
+        });
+        it('should be allowed to get pet by id', function (done) {
+            request(baseUrl).get('/pets/' + petId).expect(200).end(done);
+        });
+        it('should be allowed to put pet by id', function (done) {
+            request(baseUrl).put('/pets/' + petId).send({pets: [
+                {name: 'Joseph'}
+            ]}).expect(200).end(done);
+        });
+        it('should be allowed to patch pet by id', function (done) {
+            var patch = [
+                {
+                    op: 'replace',
+                    path: '/pets/0/name',
+                    value: 'Josephine'
+                }
+            ];
+            request(baseUrl).patch('/pets/' + petId).send(patch).expect(200).end(done);
+        });
+        it.skip('should be allowed to getChangeEventsStreaming for pet', function () {
+            throw new Error('Not implemented yet');
+        });
+    });
+});

--- a/test/roles.spec.js
+++ b/test/roles.spec.js
@@ -77,20 +77,34 @@ describe('Roles', function () {
             }
         });
         it('should be allowed to get people', function (done) {
-            request(baseUrl).get('/people').expect(200).end(done);
+            request(baseUrl)
+                .get('/people')
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to post person', function (done) {
-            request(baseUrl).post('/people').send({people: [
-                {name: 'Steve'}
-            ]}).expect(201).end(done);
+            request(baseUrl)
+                .post('/people')
+                .send({people: [
+                    {name: 'Steve'}
+                ]})
+                .expect(201)
+                .end(done);
         });
         it('should be allowed to get person by id', function (done) {
-            request(baseUrl).get('/people/' + personId).expect(200).end(done);
+            request(baseUrl)
+                .get('/people/' + personId)
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to put person by id', function (done) {
-            request(baseUrl).put('/people/' + personId).send({people: [
-                {name: 'Joseph'}
-            ]}).expect(200).end(done);
+            request(baseUrl)
+                .put('/people/' + personId)
+                .send({people: [
+                    {name: 'Joseph'}
+                ]})
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to patch person by id', function (done) {
             var patch = [
@@ -100,7 +114,11 @@ describe('Roles', function () {
                     value: 'Josephine'
                 }
             ];
-            request(baseUrl).patch('/people/' + personId).send(patch).expect(200).end(done);
+            request(baseUrl)
+                .patch('/people/' + personId)
+                .send(patch)
+                .expect(200)
+                .end(done);
         });
         it.skip('should be allowed to getChangeEventsStreaming for person', function () {
             throw new Error('Not implemented yet');
@@ -108,20 +126,34 @@ describe('Roles', function () {
 
 
         it('should be allowed to get users', function (done) {
-            request(baseUrl).get('/users').expect(200).end(done);
+            request(baseUrl)
+                .get('/users')
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to post user', function (done) {
-            request(baseUrl).post('/users').send({users: [
-                {name: 'Steve'}
-            ]}).expect(201).end(done);
+            request(baseUrl)
+                .post('/users')
+                .send({users: [
+                    {name: 'Steve'}
+                ]})
+                .expect(201)
+                .end(done);
         });
         it('should NOT be allowed to get user by id', function (done) {
-            request(baseUrl).get('/users/' + userId).expect(403).end(done);
+            request(baseUrl)
+                .get('/users/' + userId)
+                .expect(403)
+                .end(done);
         });
         it('should be allowed to put user by id', function (done) {
-            request(baseUrl).put('/users/' + userId).send({users: [
-                {name: 'Joseph'}
-            ]}).expect(200).end(done);
+            request(baseUrl)
+                .put('/users/' + userId)
+                .send({users: [
+                    {name: 'Joseph'}
+                ]})
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to patch user by id', function (done) {
             var patch = [
@@ -131,7 +163,11 @@ describe('Roles', function () {
                     value: 'Josephine'
                 }
             ];
-            request(baseUrl).patch('/users/' + userId).send(patch).expect(200).end(done);
+            request(baseUrl)
+                .patch('/users/' + userId)
+                .send(patch)
+                .expect(200)
+                .end(done);
         });
         it.skip('should be allowed to getChangeEventsStreaming for user', function () {
             throw new Error('Not implemented yet');
@@ -139,20 +175,34 @@ describe('Roles', function () {
 
 
         it('should be allowed to get pets', function (done) {
-            request(baseUrl).get('/pets').expect(200).end(done);
+            request(baseUrl)
+                .get('/pets')
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to post pet', function (done) {
-            request(baseUrl).post('/pets').send({pets: [
-                {name: 'Steve'}
-            ]}).expect(201).end(done);
+            request(baseUrl)
+                .post('/pets')
+                .send({pets: [
+                    {name: 'Steve'}
+                ]})
+                .expect(201)
+                .end(done);
         });
         it('should be allowed to get pet by id', function (done) {
-            request(baseUrl).get('/pets/' + petId).expect(200).end(done);
+            request(baseUrl)
+                .get('/pets/' + petId)
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to put pet by id', function (done) {
-            request(baseUrl).put('/pets/' + petId).send({pets: [
-                {name: 'Joseph'}
-            ]}).expect(200).end(done);
+            request(baseUrl)
+                .put('/pets/' + petId)
+                .send({pets: [
+                    {name: 'Joseph'}
+                ]})
+                .expect(200).
+                end(done);
         });
         it('should be allowed to patch pet by id', function (done) {
             var patch = [
@@ -162,7 +212,11 @@ describe('Roles', function () {
                     value: 'Josephine'
                 }
             ];
-            request(baseUrl).patch('/pets/' + petId).send(patch).expect(200).end(done);
+            request(baseUrl)
+                .patch('/pets/' + petId)
+                .send(patch)
+                .expect(200)
+                .end(done);
         });
         it.skip('should be allowed to getChangeEventsStreaming for pet', function () {
             throw new Error('Not implemented yet');
@@ -180,20 +234,34 @@ describe('Roles', function () {
             }
         });
         it('should NOT be allowed to get people', function (done) {
-            request(baseUrl).get('/people').expect(403).end(done);
+            request(baseUrl)
+                .get('/people')
+                .expect(403)
+                .end(done);
         });
         it('should NOT be allowed to post person', function (done) {
-            request(baseUrl).post('/people').send({people: [
-                {name: 'Steve'}
-            ]}).expect(403).end(done);
+            request(baseUrl)
+                .post('/people')
+                .send({people: [
+                    {name: 'Steve'}
+                ]})
+                .expect(403)
+                .end(done);
         });
         it('should NOT be allowed to get person by id', function (done) {
-            request(baseUrl).get('/people/' + personId).expect(403).end(done);
+            request(baseUrl)
+                .get('/people/' + personId)
+                .expect(403)
+                .end(done);
         });
         it('should NOT be allowed to put person by id', function (done) {
-            request(baseUrl).put('/people/' + personId).send({people: [
-                {name: 'Joseph'}
-            ]}).expect(403).end(done);
+            request(baseUrl)
+                .put('/people/' + personId)
+                .send({people: [
+                    {name: 'Joseph'}
+                ]})
+                .expect(403)
+                .end(done);
         });
         it('should NOT be allowed to patch person by id', function (done) {
             var patch = [
@@ -203,7 +271,11 @@ describe('Roles', function () {
                     value: 'Josephine'
                 }
             ];
-            request(baseUrl).patch('/people/' + personId).send(patch).expect(403).end(done);
+            request(baseUrl)
+                .patch('/people/' + personId)
+                .send(patch)
+                .expect(403)
+                .end(done);
         });
         it.skip('should NOT be allowed to getChangeEventsStreaming for person', function () {
             throw new Error('Not implemented yet');
@@ -211,20 +283,34 @@ describe('Roles', function () {
 
 
         it('should be allowed to get users', function (done) {
-            request(baseUrl).get('/users').expect(200).end(done);
+            request(baseUrl)
+                .get('/users')
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to post user', function (done) {
-            request(baseUrl).post('/users').send({users: [
-                {name: 'Steve'}
-            ]}).expect(201).end(done);
+            request(baseUrl)
+                .post('/users')
+                .send({users: [
+                    {name: 'Steve'}
+                ]})
+                .expect(201)
+                .end(done);
         });
         it('should NOT be allowed to get user by id', function (done) {
-            request(baseUrl).get('/users/' + userId).expect(403).end(done);
+            request(baseUrl)
+                .get('/users/' + userId)
+                .expect(403)
+                .end(done);
         });
         it('should be allowed to put user by id', function (done) {
-            request(baseUrl).put('/users/' + userId).send({users: [
-                {name: 'Joseph'}
-            ]}).expect(200).end(done);
+            request(baseUrl)
+                .put('/users/' + userId)
+                .send({users: [
+                    {name: 'Joseph'}
+                ]})
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to patch user by id', function (done) {
             var patch = [
@@ -234,7 +320,11 @@ describe('Roles', function () {
                     value: 'Josephine'
                 }
             ];
-            request(baseUrl).patch('/users/' + userId).send(patch).expect(200).end(done);
+            request(baseUrl)
+                .patch('/users/' + userId)
+                .send(patch)
+                .expect(200)
+                .end(done);
         });
         it.skip('should be allowed to getChangeEventsStreaming for user', function () {
             throw new Error('Not implemented yet');
@@ -242,20 +332,34 @@ describe('Roles', function () {
 
 
         it('should be allowed to get pets', function (done) {
-            request(baseUrl).get('/pets').expect(200).end(done);
+            request(baseUrl)
+                .get('/pets')
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to post pet', function (done) {
-            request(baseUrl).post('/pets').send({pets: [
-                {name: 'Steve'}
-            ]}).expect(201).end(done);
+            request(baseUrl)
+                .post('/pets')
+                .send({pets: [
+                    {name: 'Steve'}
+                ]})
+                .expect(201)
+                .end(done);
         });
         it('should be allowed to get pet by id', function (done) {
-            request(baseUrl).get('/pets/' + petId).expect(200).end(done);
+            request(baseUrl)
+                .get('/pets/' + petId)
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to put pet by id', function (done) {
-            request(baseUrl).put('/pets/' + petId).send({pets: [
-                {name: 'Joseph'}
-            ]}).expect(200).end(done);
+            request(baseUrl)
+                .put('/pets/' + petId)
+                .send({pets: [
+                    {name: 'Joseph'}
+                ]})
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to patch pet by id', function (done) {
             var patch = [
@@ -265,7 +369,11 @@ describe('Roles', function () {
                     value: 'Josephine'
                 }
             ];
-            request(baseUrl).patch('/pets/' + petId).send(patch).expect(200).end(done);
+            request(baseUrl)
+                .patch('/pets/' + petId)
+                .send(patch)
+                .expect(200)
+                .end(done);
         });
         it.skip('should be allowed to getChangeEventsStreaming for pet', function () {
             throw new Error('Not implemented yet');
@@ -283,20 +391,34 @@ describe('Roles', function () {
             }
         });
         it('should NOT be allowed to get people', function (done) {
-            request(baseUrl).get('/people').expect(403).end(done);
+            request(baseUrl)
+                .get('/people')
+                .expect(403)
+                .end(done);
         });
         it('should NOT be allowed to post person', function (done) {
-            request(baseUrl).post('/people').send({people: [
-                {name: 'Steve'}
-            ]}).expect(403).end(done);
+            request(baseUrl)
+                .post('/people')
+                .send({people: [
+                    {name: 'Steve'}
+                ]})
+                .expect(403)
+                .end(done);
         });
         it('should NOT be allowed to get person by id', function (done) {
-            request(baseUrl).get('/people/' + personId).expect(403).end(done);
+            request(baseUrl)
+                .get('/people/' + personId)
+                .expect(403)
+                .end(done);
         });
         it('should NOT be allowed to put person by id', function (done) {
-            request(baseUrl).put('/people/' + personId).send({people: [
-                {name: 'Joseph'}
-            ]}).expect(403).end(done);
+            request(baseUrl)
+                .put('/people/' + personId)
+                .send({people: [
+                    {name: 'Joseph'}
+                ]})
+                .expect(403)
+                .end(done);
         });
         it('should NOT be allowed to patch person by id', function (done) {
             var patch = [
@@ -306,7 +428,11 @@ describe('Roles', function () {
                     value: 'Josephine'
                 }
             ];
-            request(baseUrl).patch('/people/' + personId).send(patch).expect(403).end(done);
+            request(baseUrl)
+                .patch('/people/' + personId)
+                .send(patch)
+                .expect(403)
+                .end(done);
         });
         it.skip('should NOT be allowed to getChangeEventsStreaming for person', function () {
             throw new Error('Not implemented yet');
@@ -314,20 +440,34 @@ describe('Roles', function () {
 
 
         it('should NOT be allowed to get users', function (done) {
-            request(baseUrl).get('/users').expect(403).end(done);
+            request(baseUrl)
+                .get('/users')
+                .expect(403)
+                .end(done);
         });
         it('should NOT be allowed to post user', function (done) {
-            request(baseUrl).post('/users').send({users: [
-                {name: 'Steve'}
-            ]}).expect(403).end(done);
+            request(baseUrl)
+                .post('/users')
+                .send({users: [
+                    {name: 'Steve'}
+                ]})
+                .expect(403)
+                .end(done);
         });
         it('should be allowed to get user by id', function (done) {
-            request(baseUrl).get('/users/' + userId).expect(200).end(done);
+            request(baseUrl)
+                .get('/users/' + userId)
+                .expect(200)
+                .end(done);
         });
         it('should NOT be allowed to put user by id', function (done) {
-            request(baseUrl).put('/users/' + userId).send({users: [
-                {name: 'Joseph'}
-            ]}).expect(403).end(done);
+            request(baseUrl)
+                .put('/users/' + userId)
+                .send({users: [
+                    {name: 'Joseph'}
+                ]})
+                .expect(403)
+                .end(done);
         });
         it('should NOT be allowed to patch user by id', function (done) {
             var patch = [
@@ -337,7 +477,11 @@ describe('Roles', function () {
                     value: 'Josephine'
                 }
             ];
-            request(baseUrl).patch('/users/' + userId).send(patch).expect(403).end(done);
+            request(baseUrl)
+                .patch('/users/' + userId)
+                .send(patch)
+                .expect(403)
+                .end(done);
         });
         it.skip('should NOT be allowed to getChangeEventsStreaming for user', function () {
             throw new Error('Not implemented yet');
@@ -345,20 +489,34 @@ describe('Roles', function () {
 
 
         it('should be allowed to get pets', function (done) {
-            request(baseUrl).get('/pets').expect(200).end(done);
+            request(baseUrl)
+                .get('/pets')
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to post pet', function (done) {
-            request(baseUrl).post('/pets').send({pets: [
-                {name: 'Steve'}
-            ]}).expect(201).end(done);
+            request(baseUrl)
+                .post('/pets')
+                .send({pets: [
+                    {name: 'Steve'}
+                ]})
+                .expect(201)
+                .end(done);
         });
         it('should be allowed to get pet by id', function (done) {
-            request(baseUrl).get('/pets/' + petId).expect(200).end(done);
+            request(baseUrl)
+                .get('/pets/' + petId)
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to put pet by id', function (done) {
-            request(baseUrl).put('/pets/' + petId).send({pets: [
-                {name: 'Joseph'}
-            ]}).expect(200).end(done);
+            request(baseUrl)
+                .put('/pets/' + petId)
+                .send({pets: [
+                    {name: 'Joseph'}
+                ]})
+                .expect(200)
+                .end(done);
         });
         it('should be allowed to patch pet by id', function (done) {
             var patch = [
@@ -368,7 +526,11 @@ describe('Roles', function () {
                     value: 'Josephine'
                 }
             ];
-            request(baseUrl).patch('/pets/' + petId).send(patch).expect(200).end(done);
+            request(baseUrl)
+                .patch('/pets/' + petId)
+                .send(patch)
+                .expect(200)
+                .end(done);
         });
         it.skip('should be allowed to getChangeEventsStreaming for pet', function () {
             throw new Error('Not implemented yet');

--- a/test/seeder.js
+++ b/test/seeder.js
@@ -28,6 +28,7 @@ module.exports = function (harvesterInstance, baseUrl) {
             body[key] = value;
             request(baseUrl).post('/' + key).send(body).expect('Content-Type', /json/).expect(201).end(function (error, response) {
                 if (error) {
+                    console.error(response ? response.text : error);
                     reject(error);
                     return;
                 }


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33615843%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33615947%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33616329%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33618442%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33618748%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33619060%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33619199%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33619370%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33619658%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33620544%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33621359%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33621669%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33623790%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33654766%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33655043%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33655171%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%200a4bbb1bdfde12dc8a3cefb1a0a350237d57294c%20lib/route.method.js%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33621669%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Same%20as%20above%20-%20%20%20%5Cr%5Cn%20%20%20%20%20%20%20%20%5Cr%5Cnvar%20authorizationEnabled%20%3D%20%28routeMethod.authorizationRequired%20%21%3D%3D%20false%29%3B%20%5Cr%5Cnor%20%5Cr%5Cnvar%20authorizationEnabled%20%3D%20%21%21routeMethod.authorizationRequired%5Cr%5Cn%5Cr%5Cnis%20more%20readable.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-30T20%3A45%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60%21%3D%3D%20false%60%20is%20type%20safe%20comparison%20while%20%27%21%21%27%20is%20truty/falsy.%22%2C%20%22created_at%22%3A%20%222015-07-01T07%3A40%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/431064%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/blabno%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/route.method.js%3AL31-41%22%7D%2C%20%22Pull%200a4bbb1bdfde12dc8a3cefb1a0a350237d57294c%20lib/route.method.js%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33621359%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20confusing%2C%20partially%20because%20you%27re%20using%20two%20vars%20that%20seem%20nearly%20identical%2C%20and%20partially%20because%20one%20of%20them%20is%20being%20compared%20to%20routeMethod.handlerFunc%2C%20which%20seems%20insane.%20I%20understand%20that%20methodNotAllowed%20is%20a%20function-%20perhaps%20we%20need%20to%20rename%20it%20methodNotAllowedFunc%3F%5Cr%5Cn%5Cr%5CnThis%20would%20allow%20us%20to%20use%20something%20like%20routeMethodAllowed%20Or%20routeMethodNotAllowed%20as%20a%20boolean%2C%20which%20lines%20up%20with%20the%20other%20booleans%20defined%20directly%20below%20in%20terms%20of%20syntax.%20%5Cr%5Cn%5Cr%5CnAlso%2C%20you%20don%27t%20have%20to%20use%20%28%29%2C%20for%20these%20comparison%2C%20but%20you%20should%20because%20it%27ll%20make%20the%20results%20more%20obvious%20to%20someone%20glancing%20at%20the%20code.%20%5Cr%5Cn%5Cr%5CnWe%20want%20to%20prioritize%20ease%20of%20reading%20code%20over%20ease%20of%20writing%20it%2C%20since%20for%20any%20code%20you%20write%2C%20it%20is%20likely%20that%20much%20more%20time%20will%20be%20spent%20maintaining%20%26%20reading%20it%20than%20you%20spent%20writing%20it.%22%2C%20%22created_at%22%3A%20%222015-06-30T20%3A43%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/route.method.js%3AL31-41%22%7D%2C%20%22Pull%200a4bbb1bdfde12dc8a3cefb1a0a350237d57294c%20lib/harvester.js%2088%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33615947%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20thinking%20that%20you%20want%20to%20call%20this%20permissionName%20and%20.getPermissionName%2C%20since%20getPermission%20sounds%20like%20it%20returns%20a%20boolean%20that%20says%20yes%20or%20no.%22%2C%20%22created_at%22%3A%20%222015-06-30T19%3A53%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/harvester.js%3AL309-349%22%7D%2C%20%22Pull%200a4bbb1bdfde12dc8a3cefb1a0a350237d57294c%20lib/route.js%20199%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33619658%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20actually%20prefer%20when%20long%20calls%20are%20broken%20up%20and%20spread%20across%20lines%20-%20it%20makes%20the%20code%20way%20more%20readable%20than%20a%20single%20line%20would%20be.%22%2C%20%22created_at%22%3A%20%222015-06-30T20%3A28%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/route.js%3AL302-311%22%7D%2C%20%22Pull%200a4bbb1bdfde12dc8a3cefb1a0a350237d57294c%20lib/route.js%20106%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33619199%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22nice%22%2C%20%22created_at%22%3A%20%222015-06-30T20%3A24%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/route.js%3AL54-149%22%7D%2C%20%22Pull%200a4bbb1bdfde12dc8a3cefb1a0a350237d57294c%20lib/harvester.js%2080%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33615843%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20needs%20more%20comments.%20What%27s%20the%20intention%20of%20this%20code%20block%3F%22%2C%20%22created_at%22%3A%20%222015-06-30T19%3A52%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/harvester.js%3AL309-349%22%7D%2C%20%22Pull%200a4bbb1bdfde12dc8a3cefb1a0a350237d57294c%20lib/route.js%20278%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33620544%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Now%20that%20you%27ve%20added%20getById%2C%20it%27s%20not%20_really_%20restMethods%2C%20is%20it%3F%20Also%2C%20it%27s%20a%20little%20confusing%20because%20it%20looks%20like%20%20it%20%2Amight%2A%20return%20a%20list%20of%20HTTP%20methods%20that%20are%20allowed%20for%20a%20route.%20%5Cr%5Cn%5Cr%5CnActually%2C%20it%20seems%20like%20you%20could%20generate%20this%20list%20from%20the%20routeMethods%20you%20defined%20higher%20up%20%28e.g.%20this.delete%29.%20This%20would%20mean%20less%20places%20to%20maintain%20this%20list%20of%20strings%2C%20and%20would%20probably%20be%20an%20easy%20win.%5Cr%5Cn%5Cr%5CnIn%20terms%20of%20the%20name%20of%20the%20fn%2C%20perhaps%20something%20like%20getRouteMethodNames%3F%20Because%20that%27s%20really%20what%20they%20are%20-%20the%20names%20of%20the%20routeMethod%20functions.%22%2C%20%22created_at%22%3A%20%222015-06-30T20%3A36%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20already%20limited%20number%20of%20places%20this%20list%20was%20used%20by%20introducing%20this%20method.%5Cr%5CnInitially%20I%20also%20wanted%20to%20have%20that%20list%20auto%20populated%2C%20but%20couldn%27t%20find%20clear%20way%20for%20that.%22%2C%20%22created_at%22%3A%20%222015-07-01T07%3A35%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/431064%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/blabno%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/route.js%3AL980-989%22%7D%2C%20%22Pull%200a4bbb1bdfde12dc8a3cefb1a0a350237d57294c%20lib/harvester.js%20108%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33619060%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this._resource%20should%20be%20constantly%20changing%20as%20the%20app%20is%20being%20defined%2C%20so%20in%20cases%20where%20you%20call%20it%2C%20in%20general%20you%20want%20to%20also%20allow%20the%20resource%20name%20as%20param%200.%20On%20the%20other%20hand%2C%20allowing%20this%20flexibility%20does%20make%20things%20more%20complicated.%20I%20think%20we%27re%20moving%20away%20from%20complicated%20things%2C%20so%20%2A%2Aperhaps%20we%20just%20leave%20it%20like%20this%2A%2A.%22%2C%20%22created_at%22%3A%20%222015-06-30T20%3A22%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/harvester.js%3AL309-349%22%7D%2C%20%22Pull%200a4bbb1bdfde12dc8a3cefb1a0a350237d57294c%20lib/harvester.js%2093%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33616329%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%20two%20blocks%20%28the%20if%20and%20the%20else%29%20require%20deep%20thought%20to%20figure%20out%20what%20they%27re%20trying%20to%20achieve%20-%20lets%20add%20some%20nice%20comments%20about%20the%20intention%20of%20the%20code%20in%20here.%20%20It%20took%20me%2020%20minutes%20to%20figure%20out%20what%20functionality%20was%20being%20delivered%20here%2C%20and%20I%20helped%20write%20the%20functional%20spec.%5Cr%5Cn%5Cr%5CnIn%20terms%20of%20comments%2C%20was%20thinking%20something%20along%20the%20lines%20of%20%20%5Cr%5Cn%5Cr%5Cn%28for%20both%20blocks%29%20//Associates%20roles%20with%20the%20permissions%20generated%20for%20relevant%20route%2Bmethod%20combinations.%5Cr%5Cn%28for%20the%20if%20block%29%20//Since%20there%20are%20no%20allowed%20roles%20for%20this%20specific%20route%2Bmethod%2C%20only%20add%20permissions%20to%20the%20roles%20specified%20in%20the%20routeContainer%5Cr%5Cn%28for%20the%20else%20block%29%20//Make%20routeMethods%27%20roles%20override%20the%20roles%20that%20are%20specified%20at%20the%20routeContainer%20level.%5Cr%5Cn%5Cr%5CnAlternatively%2C%20you%20could%20pull%20into%20it%27s%20own%20fn%20with%20a%20good%20name.%22%2C%20%22created_at%22%3A%20%222015-06-30T19%3A57%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/harvester.js%3AL309-349%22%7D%2C%20%22Pull%200a4bbb1bdfde12dc8a3cefb1a0a350237d57294c%20test/roles.spec.js%2083%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33623790%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Would%20be%20really%20nice%20if%20you%20made%20this%20stuff%20more%20readable%20by%20taking%20advantage%20of%20newlines%3A%5Cr%5Cne.g%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20request%28baseUrl%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.post%28%27/people%27%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.send%28%7Bpeople%3A%20%5B%7Bname%3A%20%27Steve%27%7D%5D%7D%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.expect%28201%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.end%28done%29%3B%22%2C%20%22created_at%22%3A%20%222015-06-30T21%3A07%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%2C%20%7B%22body%22%3A%20%22Do%20you%20know%20how%20to%20configure%20such%20codestyle%20in%20intelliJ%3F%22%2C%20%22created_at%22%3A%20%222015-07-01T07%3A42%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/431064%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/blabno%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/roles.spec.js%3AL1-378%22%7D%2C%20%22Pull%200a4bbb1bdfde12dc8a3cefb1a0a350237d57294c%20lib/route.js%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33619370%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Using%20harvester%20rather%20than%20this%20makes%20the%20code%20way%20more%20straightforward.%20Good%20job%20there.%22%2C%20%22created_at%22%3A%20%222015-06-30T20%3A25%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/route.js%3AL18-43%22%7D%2C%20%22Pull%200a4bbb1bdfde12dc8a3cefb1a0a350237d57294c%20lib/harvester.js%20100%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33618442%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Add%20a%20comment%20here%20or%20pull%20into%20a%20fn%3A%20deduplicate%20permissions.%22%2C%20%22created_at%22%3A%20%222015-06-30T20%3A16%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/harvester.js%3AL309-349%22%7D%2C%20%22Pull%200a4bbb1bdfde12dc8a3cefb1a0a350237d57294c%20lib/harvester.js%20106%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/115%23discussion_r33618748%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Add%20comment%20on%20usage.%20Since%20this%20is%20a%20framework%2C%20commenting%20is%20super%20important.%22%2C%20%22created_at%22%3A%20%222015-06-30T20%3A19%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/harvester.js%3AL309-349%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 0a4bbb1bdfde12dc8a3cefb1a0a350237d57294c lib/harvester.js 80'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/115#discussion_r33615843'>File: lib/harvester.js:L309-349</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> This needs more comments. What's the intention of this code block?
- [ ] <a href='#crh-comment-Pull 0a4bbb1bdfde12dc8a3cefb1a0a350237d57294c lib/harvester.js 88'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/115#discussion_r33615947'>File: lib/harvester.js:L309-349</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> I'm thinking that you want to call this permissionName and .getPermissionName, since getPermission sounds like it returns a boolean that says yes or no.
- [ ] <a href='#crh-comment-Pull 0a4bbb1bdfde12dc8a3cefb1a0a350237d57294c lib/harvester.js 93'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/115#discussion_r33616329'>File: lib/harvester.js:L309-349</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> These two blocks (the if and the else) require deep thought to figure out what they're trying to achieve - lets add some nice comments about the intention of the code in here.  It took me 20 minutes to figure out what functionality was being delivered here, and I helped write the functional spec.
In terms of comments, was thinking something along the lines of
(for both blocks) //Associates roles with the permissions generated for relevant route+method combinations.
(for the if block) //Since there are no allowed roles for this specific route+method, only add permissions to the roles specified in the routeContainer
(for the else block) //Make routeMethods' roles override the roles that are specified at the routeContainer level.
Alternatively, you could pull into it's own fn with a good name.
- [ ] <a href='#crh-comment-Pull 0a4bbb1bdfde12dc8a3cefb1a0a350237d57294c lib/harvester.js 100'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/115#discussion_r33618442'>File: lib/harvester.js:L309-349</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> Add a comment here or pull into a fn: deduplicate permissions.
- [ ] <a href='#crh-comment-Pull 0a4bbb1bdfde12dc8a3cefb1a0a350237d57294c lib/harvester.js 106'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/115#discussion_r33618748'>File: lib/harvester.js:L309-349</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> Add comment on usage. Since this is a framework, commenting is super important.
- [ ] <a href='#crh-comment-Pull 0a4bbb1bdfde12dc8a3cefb1a0a350237d57294c lib/harvester.js 108'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/115#discussion_r33619060'>File: lib/harvester.js:L309-349</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> this._resource should be constantly changing as the app is being defined, so in cases where you call it, in general you want to also allow the resource name as param 0. On the other hand, allowing this flexibility does make things more complicated. I think we're moving away from complicated things, so **perhaps we just leave it like this**.
- [ ] <a href='#crh-comment-Pull 0a4bbb1bdfde12dc8a3cefb1a0a350237d57294c lib/route.js 106'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/115#discussion_r33619199'>File: lib/route.js:L54-149</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> nice
- [ ] <a href='#crh-comment-Pull 0a4bbb1bdfde12dc8a3cefb1a0a350237d57294c lib/route.js 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/115#discussion_r33619370'>File: lib/route.js:L18-43</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> Using harvester rather than this makes the code way more straightforward. Good job there.
- [ ] <a href='#crh-comment-Pull 0a4bbb1bdfde12dc8a3cefb1a0a350237d57294c lib/route.js 199'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/115#discussion_r33619658'>File: lib/route.js:L302-311</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> We actually prefer when long calls are broken up and spread across lines - it makes the code way more readable than a single line would be.
- [ ] <a href='#crh-comment-Pull 0a4bbb1bdfde12dc8a3cefb1a0a350237d57294c lib/route.js 278'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/115#discussion_r33620544'>File: lib/route.js:L980-989</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> Now that you've added getById, it's not _really_ restMethods, is it? Also, it's a little confusing because it looks like  it *might* return a list of HTTP methods that are allowed for a route.
Actually, it seems like you could generate this list from the routeMethods you defined higher up (e.g. this.delete). This would mean less places to maintain this list of strings, and would probably be an easy win.
In terms of the name of the fn, perhaps something like getRouteMethodNames? Because that's really what they are - the names of the routeMethod functions.
- <a href='https://github.com/blabno'><img border=0 src='https://avatars.githubusercontent.com/u/431064?v=3' height=16 width=16'></a> I've already limited number of places this list was used by introducing this method.
Initially I also wanted to have that list auto populated, but couldn't find clear way for that.
- [ ] <a href='#crh-comment-Pull 0a4bbb1bdfde12dc8a3cefb1a0a350237d57294c lib/route.method.js 10'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/115#discussion_r33621359'>File: lib/route.method.js:L31-41</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> This is confusing, partially because you're using two vars that seem nearly identical, and partially because one of them is being compared to routeMethod.handlerFunc, which seems insane. I understand that methodNotAllowed is a function- perhaps we need to rename it methodNotAllowedFunc?
This would allow us to use something like routeMethodAllowed Or routeMethodNotAllowed as a boolean, which lines up with the other booleans defined directly below in terms of syntax.
Also, you don't have to use (), for these comparison, but you should because it'll make the results more obvious to someone glancing at the code.
We want to prioritize ease of reading code over ease of writing it, since for any code you write, it is likely that much more time will be spent maintaining & reading it than you spent writing it.
- [ ] <a href='#crh-comment-Pull 0a4bbb1bdfde12dc8a3cefb1a0a350237d57294c lib/route.method.js 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/115#discussion_r33621669'>File: lib/route.method.js:L31-41</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> Same as above -
var authorizationEnabled = (routeMethod.authorizationRequired !== false);
or
var authorizationEnabled = !!routeMethod.authorizationRequired
is more readable.
- <a href='https://github.com/blabno'><img border=0 src='https://avatars.githubusercontent.com/u/431064?v=3' height=16 width=16'></a> `!== false` is type safe comparison while '!!' is truty/falsy.
- [ ] <a href='#crh-comment-Pull 0a4bbb1bdfde12dc8a3cefb1a0a350237d57294c test/roles.spec.js 83'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/115#discussion_r33623790'>File: test/roles.spec.js:L1-378</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> Would be really nice if you made this stuff more readable by taking advantage of newlines:
e.g:
request(baseUrl)
.post('/people')
.send({people: [{name: 'Steve'}]})
.expect(201)
.end(done);
- <a href='https://github.com/blabno'><img border=0 src='https://avatars.githubusercontent.com/u/431064?v=3' height=16 width=16'></a> Do you know how to configure such codestyle in intelliJ?


<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/115?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/115?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/115'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>