### PR TITLE
Throws error on bad GETs so error sending is correctly propagated.

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -540,7 +540,7 @@ function route(harvester, name, model, schema, routeOptions) {
                         return afterTransform(resource, req, res);
                     }));
                 } else {
-                    sendError(req, res, new JSONAPI_Error({status: 404}));
+                    throw new JSONAPI_Error({status: 404});
                 }
             })
             // send the response


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/117?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/117'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>