### PR TITLE
Provision Permissions - Export from Harvester #119

### DIFF
--- a/lib/harvester.js
+++ b/lib/harvester.js
@@ -14,7 +14,13 @@ var sendError = require('./send-error');
 /*!
  * The Harvester object.
  */
-function Harvester () {
+function Harvester() {
+    /**
+     * Store loaded schemas here.
+     *
+     * @api private
+     */
+    this._schema = {};
     this._init.apply(this, arguments);
 }
 
@@ -228,14 +234,14 @@ Harvester.prototype._convertToLegacySchema = function(schema) {
       legacySchema[key] = schemaMap[schemaItem._type];
     } else if(key === 'links') {
         _.each(schemaItem, function(linkItem, key) {
-           legacySchema[key] = linkItem; 
+           legacySchema[key] = linkItem;
         });
     } else {
 
       legacySchema[key] = schemaItem;
     }
   });
-  
+
   return legacySchema;
 
 }
@@ -353,6 +359,20 @@ Harvester.prototype.exportRoles = function () {
     return roles;
 };
 
+Harvester.prototype.exportPermissions = function () {
+    var permissions = [];
+    _.forEach(this.createdResources, function (resource) {
+        _.forEach(route.getRouteMethodNames(), function (restMethodName) {
+            var restMethod = resource[restMethodName]();
+            if (!restMethod.isAllowed()) {
+                return;
+            }
+            permissions.push(restMethod.getPermissionName());
+        });
+    });
+    return permissions;
+};
+
 /**
  * Set roles allowed to access most recently defined/referenced resource.
  *
@@ -433,6 +453,7 @@ Harvester.prototype._removeRoutes = function (name, methods, routes) {
 
   this.adapter.awaitConnection().then(function () {
     (methods || []).forEach(function (verb) {
+//        TODO imho this method is badly implemented. `router` does not have `routes` property.
       var paths = router.routes[verb];
       paths.forEach(function (route, index) {
         if (routes ? _.contains(routes, route.path) : re.test(route.path)) {
@@ -452,12 +473,29 @@ Harvester.prototype._removeRoutes = function (name, methods, routes) {
  * @return {this}
  */
 Harvester.prototype.readOnly = function (name) {
-  if (typeof name !== 'string') {
-    name = this._resource;
-  }
+    if (typeof name !== 'string') {
+        name = this._resource;
+    }
 
-  this._removeRoutes(name, ['post', 'put', 'patch', 'delete']);
-  return this;
+    this.createdResources[name].readOnly();
+    return this;
+};
+
+/**
+ * Mark a resource as immutable, which destroys the routes
+ * for `PUT`, `PATCH`, and `DELETE` on that resource. The resource
+ * can still be modified using adapter methods.
+ *
+ * @param {String} [name] if no name is passed, the last defined resource is used.
+ * @return {this}
+ */
+Harvester.prototype.immutable = function (name) {
+    if (typeof name !== 'string') {
+        name = this._resource;
+    }
+
+    this.createdResources[name].immutable();
+    return this;
 };
 
 /**
@@ -507,13 +545,6 @@ Harvester.prototype.router = {};
  * Namespace for the adapter.
  */
 Harvester.prototype.adapter = {};
-
-/**
- * Store loaded schemas here.
- *
- * @api private
- */
-Harvester.prototype._schema = {};
 
 /**
  * Store methods to transform input.

--- a/lib/route.js
+++ b/lib/route.js
@@ -955,6 +955,23 @@ function route(harvester, name, model, schema, routeOptions) {
     }
 
     this.appendLinks = appendLinks;
+
+    function disallow(methods) {
+        _.forEach(methods, function (methodName) {
+            var method = _this[methodName]();
+            method.options.notAllowed = true;
+            method.register();
+        });
+    }
+
+    this.readOnly = function () {
+        disallow(['post', 'putById', 'deleteById', 'patchById']);
+    };
+
+    this.immutable = function () {
+        disallow(['putById', 'deleteById', 'patchById']);
+    };
+
     return this;
 }
 /*

--- a/lib/route.method.js
+++ b/lib/route.method.js
@@ -139,6 +139,15 @@ RouteMethod.prototype.validate = function (validateFunc) {
     return this;
 };
 
+RouteMethod.prototype.notAllowed = function () {
+    this.options.notAllowed = true;
+    return this;
+};
+
+RouteMethod.prototype.isAllowed = function () {
+    return this.handlerFunc !== methodNotAllowedFunc;
+};
+
 RouteMethod.prototype.roles = function () {
     this.roles = Array.prototype.slice.call(arguments);
     return this;

--- a/test/app.js
+++ b/test/app.js
@@ -32,7 +32,7 @@ function configureApp(harvesterApp) {
     .resource('cat', {
         name: Joi.string().required().description('name'),
         hasToy: Joi.boolean().required().description('hasToy'),
-        numToys: Joi.number().required().description('numToys'),
+        numToys: Joi.number().required().description('numToys')
     }, {namespace: 'animals'})
 
     .resource('foobar', {
@@ -59,7 +59,17 @@ function configureApp(harvesterApp) {
         } else {
             return foobar;
         }
-    });
+    })
+
+    .resource('readers', {
+        name: Joi.string().description('name')
+    })
+    .readOnly()
+
+    .resource('immutable', {
+        name: Joi.string().description('name')
+    })
+    .immutable();
 
 
     harvesterApp.router.get('/random-error', function (req, res, next) {

--- a/test/exportPermissions.spec.js
+++ b/test/exportPermissions.spec.js
@@ -1,0 +1,29 @@
+var Joi = require('joi');
+var expect = require('chai').expect;
+
+var harvester = require('../lib/harvester');
+var config = require('./config.js');
+
+describe('Export permissions', function () {
+
+    var harvesterInstance;
+
+    before(function () {
+        harvesterInstance = harvester(config.harvester.options);
+        var resourceSchema = {name: Joi.string()};
+        harvesterInstance.resource('person', resourceSchema).readOnly();
+        harvesterInstance.resource('pet', resourceSchema);
+        harvesterInstance.resource('user', resourceSchema).immutable();
+    });
+
+    it('should export 14 permissions, excluding disallowed ones', function () {
+        var expectedPermissions = [
+            'person.get', 'person.getById', 'person.getChangeEventsStreaming',
+            'pet.get', 'pet.post', 'pet.getById', 'pet.putById', 'pet.deleteById', 'pet.patchById', 'pet.getChangeEventsStreaming',
+            'user.get', 'user.post', 'user.getById', 'user.getChangeEventsStreaming'
+        ];
+        var exportedPermissions = harvesterInstance.exportPermissions();
+        expect(exportedPermissions).to.eql(expectedPermissions);
+    });
+
+});

--- a/test/fixtures/immutables.js
+++ b/test/fixtures/immutables.js
@@ -1,0 +1,8 @@
+module.exports = (function () {
+  return [
+    {
+      "id": "c344d722-b7f9-49dd-9842-f0a375f7dfdc",
+      "name": "Imbert"
+    }
+  ];
+}());

--- a/test/fixtures/readers.js
+++ b/test/fixtures/readers.js
@@ -1,0 +1,8 @@
+module.exports = (function () {
+  return [
+    {
+      "id": "c344d722-b7f9-49dd-9842-f0a375f7dfdc",
+      "name": "Rodbert"
+    }
+  ];
+}());

--- a/test/immutable.spec.js
+++ b/test/immutable.spec.js
@@ -1,0 +1,76 @@
+var should = require('should');
+var supertest = require('supertest');
+var seeder = require('./seeder.js');
+
+describe('Immutable', function () {
+
+    var config;
+    var ids;
+
+    beforeEach(function () {
+        config = this.config;
+        return seeder(this.harvesterApp).dropCollectionsAndSeed('immutables').then(function (_ids) {
+            ids = _ids;
+        });
+    });
+
+    it('should be possible to post', function (done) {
+        var data = {
+            immutables: [
+                {name: 'Jack'}
+            ]
+        };
+        supertest(config.baseUrl).post('/immutables').send(data).expect('Content-Type', /json/).expect(201).end(function (error) {
+            should.not.exist(error);
+            done();
+        });
+    });
+
+    it('should be possible to get', function (done) {
+        supertest(config.baseUrl).get('/readers').expect('Content-Type', /json/).expect(200).end(function (error) {
+            should.not.exist(error);
+            done();
+        });
+    });
+
+    it('should be possible to getById', function (done) {
+        supertest(config.baseUrl).get('/immutables/' + ids.immutables[0]).expect('Content-Type', /json/).expect(200).end(function (error) {
+            should.not.exist(error);
+            done();
+        });
+    });
+
+    it('should NOT be possible to deleteById', function (done) {
+        supertest(config.baseUrl).delete('/immutables/' + ids.immutables[0]).expect('Content-Type', /json/).expect(405).end(function (error) {
+            should.not.exist(error);
+            done();
+        });
+    });
+
+    it('should NOT be possible to putById', function (done) {
+        var data = {
+            immutables: [
+                {name: 'Duck'}
+            ]
+        };
+        supertest(config.baseUrl).put('/immutables/' + ids.immutables[0]).send(data).expect('Content-Type', /json/).expect(405).end(function (error) {
+            should.not.exist(error);
+            done();
+        });
+    });
+
+    it('should NOT be possible to patchById', function (done) {
+        var data = [
+            {
+                op: 'replace',
+                path: '/immutables/0/name',
+                value: 'Baba Jaga'
+            }
+        ];
+        supertest(config.baseUrl).patch('/immutables/' + ids.immutables[0]).send(data).expect('Content-Type', /json/).expect(405).end(function (error) {
+            should.not.exist(error);
+            done();
+        });
+    });
+
+});

--- a/test/readOnly.spec.js
+++ b/test/readOnly.spec.js
@@ -1,0 +1,89 @@
+var should = require('should');
+var supertest = require('supertest');
+var Joi = require('joi');
+var harvester = require('../lib/harvester');
+var seeder = require('./seeder.js');
+
+describe('ReadOnly', function () {
+
+    var config;
+    var ids;
+    var seedingPort = 8010;
+
+    before(function () {
+        config = this.config;
+        var seedingHarvesterInstance = harvester(config.harvester.options);
+        seedingHarvesterInstance.resource('readers', {
+            name: Joi.string().description('name')
+        });
+        seedingHarvesterInstance.listen(seedingPort);
+        this.seedingHarvesterInstance = seedingHarvesterInstance;
+    });
+
+    beforeEach(function () {
+
+        return seeder(this.seedingHarvesterInstance, 'http://localhost:' + seedingPort).dropCollectionsAndSeed('readers').then(function (_ids) {
+            ids = _ids;
+        });
+    });
+
+    it('should NOT be possible to post', function (done) {
+        var data = {
+            readers: [
+                {name: 'Jack'}
+            ]
+        };
+        supertest(config.baseUrl).post('/readers').send(data).expect('Content-Type', /json/).expect(405).end(function (error) {
+            should.not.exist(error);
+            done();
+        });
+    });
+
+    it('should be possible to get', function (done) {
+        supertest(config.baseUrl).get('/readers').expect('Content-Type', /json/).expect(200).end(function (error) {
+            should.not.exist(error);
+            done();
+        });
+    });
+
+    it('should be possible to getById', function (done) {
+        supertest(config.baseUrl).get('/readers/' + ids.readers[0]).expect('Content-Type', /json/).expect(200).end(function (error) {
+            should.not.exist(error);
+            done();
+        });
+    });
+
+    it('should NOT be possible to deleteById', function (done) {
+        supertest(config.baseUrl).delete('/readers/' + ids.readers[0]).expect('Content-Type', /json/).expect(405).end(function (error) {
+            should.not.exist(error);
+            done();
+        });
+    });
+
+    it('should NOT be possible to putById', function (done) {
+        var data = {
+            readers: [
+                {name: 'Duck'}
+            ]
+        };
+        supertest(config.baseUrl).put('/readers/' + ids.readers[0]).send(data).expect('Content-Type', /json/).expect(405).end(function (error) {
+            should.not.exist(error);
+            done();
+        });
+    });
+
+    it('should NOT be possible to patchById', function (done) {
+        var data = [
+            {
+                op: 'replace',
+                path: '/readers/0/name',
+                value: 'Baba Jaga'
+            }
+        ];
+        supertest(config.baseUrl).patch('/readers/' + ids.readers[0]).send(data).expect('Content-Type', /json/).expect(405).end(function (error) {
+            should.not.exist(error);
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34588565%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34588693%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34588775%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34588818%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34588937%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34589348%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34885076%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34888591%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34888758%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%209fd1887b18c552530c0a128d593d61913e8680b8%20lib/route.method.js%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34589348%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20see%20isAllowed%20and%20notAllowed%2C%20and%20they%20seem%20very%20different%2C%20and%20surprisingly%20so.%20notAllowed%20seems%20to%20be%20a%20setter%20with%20a%20default%20value.%20I%20would%20expect%20it%20to%20look%20something%20like%20setAllowed%28false%29%20or%20setNotAllowed%28%29%20-%20the%20keyword%20%5C%22set%5C%22%20would%20let%20us%20know%20that%20this%20is%20a%20setter.%22%2C%20%22created_at%22%3A%20%222015-07-14T16%3A38%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%2C%20%7B%22body%22%3A%20%22A%20bit%20confused%20by%20this%20-%20disable/Enable%20is%20pretty%20clear%20to%20me%3B%20if%20you%27d%20called%20this%20DisallowHTTPRoute%2C%20then%20this%20would%20be%20clearer...%20Maybe%20we%20need%20to%20chat%20about%20this%20one%20in%20real-time.%22%2C%20%22created_at%22%3A%20%222015-07-17T13%3A31%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/route.method.js%3AL139-154%22%7D%2C%20%22Pull%209fd1887b18c552530c0a128d593d61913e8680b8%20lib/harvester.js%2086%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34588775%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22v%20nice.%22%2C%20%22created_at%22%3A%20%222015-07-14T16%3A32%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/harvester.js%3AL473-502%22%7D%2C%20%22Pull%209fd1887b18c552530c0a128d593d61913e8680b8%20lib/harvester.js%2057%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34588693%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20dont%20think%20this%20works%3B%20express%20does%20not%20have%20an%20api%20for%20deregistering%20routes%2C%20so%20what%20you%27re%20seeing%20is%20a%20hack%20that%20may%20have%20worked%20for%20an%20earlier%20version%20of%20express.%22%2C%20%22created_at%22%3A%20%222015-07-14T16%3A32%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%2C%20%7B%22body%22%3A%20%22For%20now%2C%20just%20leave%20it.%20The%20comment%20is%20enough.%22%2C%20%22created_at%22%3A%20%222015-07-17T12%3A38%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/harvester.js%3AL453-460%22%7D%2C%20%22Pull%209fd1887b18c552530c0a128d593d61913e8680b8%20lib/route.js%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34588937%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Not%20sure%20if%20disallow%20should%20automatically%20call%20register...%20I%20think%20the%20intention%20was%20that%20register%20would%20still%20need%20to%20be%20called%22%2C%20%22created_at%22%3A%20%222015-07-14T16%3A34%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20wanted%20the%20.register%20call%20so%20that%20you%20could%20externally%20decide%20whether%20or%20not%20a%20route%20gets%20registered-%20otherwise%20you%20have%20little%20control%20over%20the%20order%20that%20routes%20get%20created%20and%20registered%20in.%20I%20think%20we%20did%20a%20bad%20job%20of%20communicating%20this%2C%20so%20register%20wound%20up%20getting%20called%20inside%20of%20harvester%2C%20which%20makes%20it%20sort%20of%20worthless%20for%20the%20moment.%20I%20think%20the%20preferred%20behaviour%20is%20that%20there%20is%20an%20additional%20property%2C%20or%20that%20you%20rely%20on%20some%20configuration%20that%20lets%20you%20know%20which%20routes%20should%20be%20registered%20and%20which%20should%20not%20be%22%2C%20%22created_at%22%3A%20%222015-07-17T13%3A29%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/route.js%3AL955-978%22%7D%2C%20%22Pull%209fd1887b18c552530c0a128d593d61913e8680b8%20lib/harvester.js%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34588565%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20was%20imagining%20that%20you%27d%20build%20the%20list%20of%20permissions%20as%20you%20were%20registering%20routes%2C%20so%20that%20this%20method%20would%20be%20O%281%29%2C%20but%20this%20approach%20also%20makes%20sense%20since%20it%20means%20we%20don%27t%20have%20to%20register%20routes%20to%20know%20which%20permissions%20are%20exportable.%20%20Nice.%22%2C%20%22created_at%22%3A%20%222015-07-14T16%3A31%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/harvester.js%3AL359-379%22%7D%2C%20%22Pull%209fd1887b18c552530c0a128d593d61913e8680b8%20lib/route.js%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/120%23discussion_r34588818%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22very%20nice%21%22%2C%20%22created_at%22%3A%20%222015-07-14T16%3A33%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/route.js%3AL955-978%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 9fd1887b18c552530c0a128d593d61913e8680b8 lib/harvester.js 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/120#discussion_r34588565'>File: lib/harvester.js:L359-379</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> I was imagining that you'd build the list of permissions as you were registering routes, so that this method would be O(1), but this approach also makes sense since it means we don't have to register routes to know which permissions are exportable.  Nice.
- [ ] <a href='#crh-comment-Pull 9fd1887b18c552530c0a128d593d61913e8680b8 lib/harvester.js 57'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/120#discussion_r34588693'>File: lib/harvester.js:L453-460</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> I dont think this works; express does not have an api for deregistering routes, so what you're seeing is a hack that may have worked for an earlier version of express.
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> For now, just leave it. The comment is enough.
- [x] <a href='#crh-comment-Pull 9fd1887b18c552530c0a128d593d61913e8680b8 lib/harvester.js 86'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/120#discussion_r34588775'>File: lib/harvester.js:L473-502</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> v nice.
- [x] <a href='#crh-comment-Pull 9fd1887b18c552530c0a128d593d61913e8680b8 lib/route.js 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/120#discussion_r34588818'>File: lib/route.js:L955-978</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> very nice!
- [ ] <a href='#crh-comment-Pull 9fd1887b18c552530c0a128d593d61913e8680b8 lib/route.js 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/120#discussion_r34588937'>File: lib/route.js:L955-978</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> Not sure if disallow should automatically call register... I think the intention was that register would still need to be called
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> We wanted the .register call so that you could externally decide whether or not a route gets registered- otherwise you have little control over the order that routes get created and registered in. I think we did a bad job of communicating this, so register wound up getting called inside of harvester, which makes it sort of worthless for the moment. I think the preferred behaviour is that there is an additional property, or that you rely on some configuration that lets you know which routes should be registered and which should not be
- [ ] <a href='#crh-comment-Pull 9fd1887b18c552530c0a128d593d61913e8680b8 lib/route.method.js 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/120#discussion_r34589348'>File: lib/route.method.js:L139-154</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> I see isAllowed and notAllowed, and they seem very different, and surprisingly so. notAllowed seems to be a setter with a default value. I would expect it to look something like setAllowed(false) or setNotAllowed() - the keyword "set" would let us know that this is a setter.
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> A bit confused by this - disable/Enable is pretty clear to me; if you'd called this DisallowHTTPRoute, then this would be clearer... Maybe we need to chat about this one in real-time.


<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/120?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/120?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/120'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>