### PR TITLE
Adds test cases for auth returning promisified errors

### DIFF
--- a/lib/harvester.js
+++ b/lib/harvester.js
@@ -530,7 +530,7 @@ Harvester.prototype.noIndex = function (name) {
  * harvester.setAuthorizationStrategy(function(req){
  *     //Here's all possible return types and how they should be handled.
  *     return promise;
- *          //resolved means authorized if not an instance of Error,
+ *          //resolved means authorized if not an instance of Error or JSONAPI_Error,
 *           //if resolved promise is err or jsonapi error, treated as below
  *          //rejected means not authorized and return 403 jsonapi error.
  *     return JSONAPI_Error; //serialize and send this jsonapi error

--- a/lib/harvester.js
+++ b/lib/harvester.js
@@ -529,7 +529,9 @@ Harvester.prototype.noIndex = function (name) {
  *
  * harvester.setAuthorizationStrategy(function(req){
  *     //Here's all possible return types and how they should be handled.
- *     return promise;//resolved means authorized, rejected means not authorized. Return 403 jsonapi error.
+ *     return promise;//resolved means authorized,
+*           //if resolved promise is err or jsonapi error, treated as below
+ *          //rejected means not authorized and return 403 jsonapi error.
  *     return JSONAPI_Error; //serialize and send this jsonapi error
  *
  *     throw new Error; //should become a 500 error by default, which is correct here.

--- a/lib/harvester.js
+++ b/lib/harvester.js
@@ -529,7 +529,8 @@ Harvester.prototype.noIndex = function (name) {
  *
  * harvester.setAuthorizationStrategy(function(req){
  *     //Here's all possible return types and how they should be handled.
- *     return promise;//resolved means authorized,
+ *     return promise;
+ *          //resolved means authorized if not an error,
 *           //if resolved promise is err or jsonapi error, treated as below
  *          //rejected means not authorized and return 403 jsonapi error.
  *     return JSONAPI_Error; //serialize and send this jsonapi error

--- a/lib/harvester.js
+++ b/lib/harvester.js
@@ -530,7 +530,7 @@ Harvester.prototype.noIndex = function (name) {
  * harvester.setAuthorizationStrategy(function(req){
  *     //Here's all possible return types and how they should be handled.
  *     return promise;
- *          //resolved means authorized if not an error,
+ *          //resolved means authorized if not an instance of Error,
 *           //if resolved promise is err or jsonapi error, treated as below
  *          //rejected means not authorized and return 403 jsonapi error.
  *     return JSONAPI_Error; //serialize and send this jsonapi error

--- a/test/authorization.spec.js
+++ b/test/authorization.spec.js
@@ -83,11 +83,11 @@ describe('authorization', function () {
     describe('when authorizationStrategy returns JSONAPI_Error promise', function () {
         beforeEach(function () {
             authorizationStrategy = function () {
-                return Promise.resolve(new JSONAPI_Error({status: 403}));
+                return Promise.resolve(new JSONAPI_Error({status: 499}));
             }
         });
         it('should return the same status code', function (done) {
-            request(baseUrl).get('/categories').expect('Content-Type', /json/).expect(403).end(done);
+            request(baseUrl).get('/categories').expect('Content-Type', /json/).expect(499).end(done);
         });
     });
 

--- a/test/authorization.spec.js
+++ b/test/authorization.spec.js
@@ -47,6 +47,61 @@ describe('authorization', function () {
         });
     });
 
+    describe('when authorizationStrategy returns custom JSONAPI_Error', function () {
+        beforeEach(function () {
+            authorizationStrategy = function () {
+                return new JSONAPI_Error({status: 403});
+            }
+        });
+        it('should return the same status code', function (done) {
+            request(baseUrl).get('/categories').expect('Content-Type', /json/).expect(403).end(done);
+        });
+    });
+
+    describe('when authorizationStrategy throws error', function () {
+        beforeEach(function () {
+            authorizationStrategy = function () {
+                return new Error;
+            }
+        });
+        it('should return 500 status code', function (done) {
+            request(baseUrl).get('/categories').expect('Content-Type', /json/).expect(500).end(done);
+        });
+    });
+
+    describe('when authorizationStrategy throws JSONAPI_Error', function () {
+        beforeEach(function () {
+            authorizationStrategy = function () {
+                return new JSONAPI_Error({status: 403});
+            }
+        });
+        it('should return the same status code', function (done) {
+            request(baseUrl).get('/categories').expect('Content-Type', /json/).expect(403).end(done);
+        });
+    });
+
+    describe('when authorizationStrategy returns JSONAPI_Error promise', function () {
+        beforeEach(function () {
+            authorizationStrategy = function () {
+                return Promise.resolve(new JSONAPI_Error({status: 403}));
+            }
+        });
+        it('should return the same status code', function (done) {
+            request(baseUrl).get('/categories').expect('Content-Type', /json/).expect(403).end(done);
+        });
+    });
+
+    describe('when authorizationStrategy returns Error promise', function () {
+        beforeEach(function () {
+            authorizationStrategy = function () {
+                return Promise.resolve(new Error);
+            }
+        });
+        it('should return the same status code', function (done) {
+            request(baseUrl).get('/categories').expect('Content-Type', /json/).expect(500).end(done);
+        });
+    });
+
     describe('when authorizationStrategy returns resolved promise', function () {
         beforeEach(function () {
             authorizationStrategy = function () {


### PR DESCRIPTION
Signed-off-by: Braden O'Guinn <braden.oguinn@mutualmobile.com>
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/agco/harvesterjs/pull/137%23discussion_r37912062%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/137%23discussion_r37912266%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%209879a17f7abb8481c9ee352e88175d48325b3030%20lib/harvester.js%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/137%23discussion_r37912062%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22resolved%20no%20longer%20means%20authorized%20-%20it%20only%20means%20authorized%20if%20you%20don%27t%20return%20an%20error%20or%20jsonapi%20error.%22%2C%20%22created_at%22%3A%20%222015-08-25T20%3A01%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/harvester.js%3AL529-538%22%7D%2C%20%22Pull%209879a17f7abb8481c9ee352e88175d48325b3030%20test/authorization.spec.js%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/137%23discussion_r37912266%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cr%5Cnonly%201%20issue%20with%20yuor%20tests%20-%20they%20pretty%20much%20excersize%20403%27s%2C%20and%20403%20was%20the%20issue%20earlier%5Cr%5Cnso%20if%20there%20was%20an%20issue%2C%20you%20might%20not%20catch%20it%5Cr%5Cnmay%20make%20sense%20to%20throw%20an%20error%20code%20that%20isn%27t%20really%20used%20in%20the%20app%2C%20like%20499%22%2C%20%22created_at%22%3A%20%222015-08-25T20%3A03%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/authorization.spec.js%3AL47-108%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 9879a17f7abb8481c9ee352e88175d48325b3030 lib/harvester.js 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/137#discussion_r37912062'>File: lib/harvester.js:L529-538</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> resolved no longer means authorized - it only means authorized if you don't return an error or jsonapi error.
- [ ] <a href='#crh-comment-Pull 9879a17f7abb8481c9ee352e88175d48325b3030 test/authorization.spec.js 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/137#discussion_r37912266'>File: test/authorization.spec.js:L47-108</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> only 1 issue with yuor tests - they pretty much excersize 403's, and 403 was the issue earlier
so if there was an issue, you might not catch it
may make sense to throw an error code that isn't really used in the app, like 499


<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/137?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/137?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/137'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>