### PR TITLE
Feature/connections

### DIFF
--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -14,38 +14,37 @@ var rgxReplSet = /^.+,.+$/;
 function Adapter() {
     var adapter = {};
     adapter._init = function (options) {
-        var connectionString = options.connectionString || '';
 
-        if (!connectionString.length) {
-            connectionString = 'mongodb://' +
-            (options.username ? options.username + ':' + options.password + '@' : '') +
-            options.host + (options.port ? ':' + options.port : '') + '/' + options.db;
-        }
+      if (this.db && this.db._readyState === 1) {
+          return;
+      }
 
+      var connectionString = options.connectionString || '';
+      if (!connectionString.length) {
+          connectionString = 'mongodb://' +
+          (options.username ? options.username + ':' + options.password + '@' : '') +
+          options.host + (options.port ? ':' + options.port : '') + '/' + options.db;
+      }
 
-        var db = mongoose.createConnection();
-        db.on('error', function (err) {
-            if (err) // couldn't connect
+      // always include keepAlive in connection options
+      // see: http://mongoosejs.com/docs/connections.html
+      var keepAlive = {keepAlive: 1};
+      var gooseOpt = options.flags || {};
+      gooseOpt.server = gooseOpt.server || {};
+      gooseOpt.server.socketOptions = gooseOpt.server.socketOptions || {};
+      _.assign(gooseOpt.server.socketOptions, keepAlive);
+      if (rgxReplSet.test(connectionString)) {
+        gooseOpt.replset = gooseOpt.replset || {};
+        gooseOpt.replset.socketOptions = gooseOpt.replset.socketOptions || {};
+        _.assign(gooseOpt.replset.socketOptions, keepAlive);
+      }
 
-            // hack the driver to allow re-opening after initial network error
-                db.db.close();
+      this.db = mongoose.createConnection(connectionString, gooseOpt);
 
-            // retry if desired
-            connect();
-        });
+      this.db.on('error', function(err){
+        // throw err;
+      });
 
-        function connect () {
-            //Should handle replsets differently from regular connectionstrings.
-            if (rgxReplSet.test(connectionString)) {
-                db.openSet(connectionString, options.flags);
-            } else {
-                db.open(connectionString, options.flags);
-            }
-        }
-
-        connect();
-
-        this.db = db;
     };
 
     /**


### PR DESCRIPTION
force keepAlive, and also let mongoose auto_reconnect handle reconnection instead of doing it ourselves. this should prevent additional connections getting opened unintentionally.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/161?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/161'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>