### PR TITLE
1368 - Harvester opens too many connections

### DIFF
--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -14,38 +14,38 @@ var rgxReplSet = /^.+,.+$/;
 function Adapter() {
     var adapter = {};
     adapter._init = function (options) {
-        var connectionString = options.connectionString || '';
+      var connectionString = options.connectionString || '';
+      var oplogConnectionString = options.oplogConnectionString || '';
 
-        if (!connectionString.length) {
-            connectionString = 'mongodb://' +
-            (options.username ? options.username + ':' + options.password + '@' : '') +
-            options.host + (options.port ? ':' + options.port : '') + '/' + options.db;
-        }
+      if (!connectionString.length) {
+          connectionString = 'mongodb://' +
+          (options.username ? options.username + ':' + options.password + '@' : '') +
+          options.host + (options.port ? ':' + options.port : '') + '/' + options.db;
+      }
 
+      // always include keepAlive in connection options
+      // see: http://mongoosejs.com/docs/connections.html
+      var keepAlive = {keepAlive: 1};
+      var gooseOpt = options.flags || {};
+      gooseOpt.server = gooseOpt.server || {};
+      gooseOpt.server.socketOptions = gooseOpt.server.socketOptions || {};
+      _.assign(gooseOpt.server.socketOptions, keepAlive);
+      if (rgxReplSet.test(connectionString)) {
+        gooseOpt.replset = gooseOpt.replset || {};
+        gooseOpt.replset.socketOptions = gooseOpt.replset.socketOptions || {};
+        _.assign(gooseOpt.replset.socketOptions, keepAlive);
+      }
 
-        var db = mongoose.createConnection();
-        db.on('error', function (err) {
-            if (err) // couldn't connect
+      function handleDbError(err){
+        console.error(err);
+        throw err;
+      }
 
-            // hack the driver to allow re-opening after initial network error
-                db.db.close();
+      this.db = mongoose.createConnection(connectionString, gooseOpt);
+      this.db.on('error', handleDbError);
 
-            // retry if desired
-            connect();
-        });
-
-        function connect () {
-            //Should handle replsets differently from regular connectionstrings.
-            if (rgxReplSet.test(connectionString)) {
-                db.openSet(connectionString, options.flags);
-            } else {
-                db.open(connectionString, options.flags);
-            }
-        }
-
-        connect();
-
-        this.db = db;
+      this.oplogDB = mongoose.createConnection(oplogConnectionString, gooseOpt);
+      this.oplogDB.on('error', handleDbError);
     };
 
     /**
@@ -230,17 +230,17 @@ function Adapter() {
     adapter.awaitConnection = function () {
         var _this = this;
         return new Promise(function (resolve, reject) {
+            // check whether db isn't already in connected state
+            // if so it wil not emit the connected event and therefore can keep the promise dangling
+            if (_this.db._readyState == 1) {
+                return resolve();
+            }
             _this.db.once('connected', function () {
                 resolve();
             });
             _this.db.once('error', function (error) {
                 reject(error);
             });
-            // check whether db isn't already in connected state
-            // if so it wil not emit the connected event and therefore can keep the promise dangling
-            if (_this.db._readyState == 1) {
-                resolve();
-            }
 
         });
     };

--- a/lib/harvester.js
+++ b/lib/harvester.js
@@ -106,10 +106,7 @@ Harvester.prototype._init = function (options) {
   this.router = express();
   router = this.router;
 
-  this.multiSSE = new SSE();
-  this.multiSSE.init({
-    context: this
-  });
+
 
   // Setup express.
   if (typeof options.cors === 'boolean' || typeof options.cors === 'object' && options.cors) {
@@ -131,6 +128,10 @@ Harvester.prototype._init = function (options) {
         }
     });
 
+  this.multiSSE = new SSE();
+  this.multiSSE.init({
+    context: this
+  });
 };
 
 /**

--- a/lib/sse.js
+++ b/lib/sse.js
@@ -56,25 +56,15 @@ SSE.prototype.init = function(config) {
     //wraps it up in an array of single item, so that it fits the current logic without too many conditions
     this.singleResourceName = config.singleResourceName && [config.singleResourceName];
     var that = this;
-    
-    this.db =  mongoose.createConnection(this.options.oplogConnectionString);
-    
-    this.db.on('error', function (err) {
-        if(err) {
-            console.log(err);
-            that.db.db.close();
-        }
-    });
-    
+
+    this.db = this.harvesterApp.adapter.oplogDB;
+
     var routePrefix =  '';
 
     if (config.singleResourceName) {
         var pluralName = (this.options.inflect) ? inflect.pluralize(config.singleResourceName) : config.singleResourceName;
-
         routePrefix = '/' + pluralName;
     }
-
-
 
     this.harvesterApp.router.get(this.options.baseUrl + routePrefix + '/changes/stream', this.requestValidationMiddleware.bind(this), tinySSE.head(), tinySSE.ticker({seconds: 3}), this.handler.bind(this));
 };
@@ -124,7 +114,7 @@ SSE.prototype.requestValidationMiddleware = function (req, res, next) {
 };
 
 SSE.prototype.handler = function (req, res, next) {
-    
+
     var that = this;
     var options = {
         tailable: true,
@@ -132,7 +122,7 @@ SSE.prototype.handler = function (req, res, next) {
         oplogReplay: true,
         numberOfRetries: Number.MAX_VALUE
     };
-    
+
     this.routeNames = req.query.resources ? req.query.resources.split(',') : [];
 
     if (this.singleResourceName) {
@@ -148,39 +138,39 @@ SSE.prototype.handler = function (req, res, next) {
             var docStream = hl(stream);
 
             docStream.resume();
-    
+
             var consume = hl().consume(function(err, chunk, push, next) {
                 var resourceNames = _.map(that.routeNames, function(routeName) {
                     var pluralName = (that.options.inflect) ? inflect.pluralize(routeName) : routeName;
                     return new RegExp(pluralName, 'i');
                 });
-                
+
                 var matchesEitherResource = _.some(resourceNames, function(resourceName) {
                     return resourceName.test(chunk.ns);
                 });
-        
+
                 if (matchesEitherResource) {
                     var id = chunk.ts.getHighBits() + '_' + chunk.ts.getLowBits();
                     var eventName = that.getEventName(that.routeNames, chunk);
                     var data = that.getData(that.routeNames[0], chunk);
-    
+
                     var filters = that.getFilters(req);
-    
+
                     var passedFilter = _.reduce(filters, function(obj, filter) {
                         return _.filter([data], _.matches(filter));
                     }, true);
-    
+
                     //if we have filters, make sure they are passed
                     if (passedFilter.length > 0 || filters.length === 0) {
                         tinySSE.send({id: id, event: eventName, data: data})(req, res);
                     }
-    
+
                     next();
                 } else {
                     next();
                 }
             });
-    
+
             docStream.through(consume).errors(function(err) {
                 console.log('HARVESTER SSE ERROR>>> ' + err.stack)
                 that.handleError(err, res, docStream);

--- a/test/singleRouteSSE.spec.js
+++ b/test/singleRouteSSE.spec.js
@@ -152,7 +152,6 @@ describe('EventSource implementation for resource changes', function () {
             it('Then an SSE is broadcast with event set to x_update, ID set to the oplog timestamp' +
                  'and data set to an instance of x that only contains the new value for property y', function (done) {
                 var that = this;
-                var counter = 0;
 
                 var payloads = [
                     {
@@ -183,12 +182,9 @@ describe('EventSource implementation for resource changes', function () {
                         });
                     }
 
-                    expect(_.omit(data, 'id')).to.deep.equal(payloads[counter].books[0]);
-                    counter ++;
-                    if (counter === 1) {
-                        done();
-                        eventSource.destroy();
-                    }
+                    expect(_.omit(data, 'id')).to.deep.equal(payloads[1].books[0]);
+                    done();
+                    eventSource.destroy();
                 });
             });
         });


### PR DESCRIPTION
SSE was opening a connection pool each time it was initialized. 

This moves the SSE connection out of SSE.init() into the mongodb adapter with the main connection, and sets keepAlive as a default option for both connections.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/162?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/162'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>