### PR TITLE
Goose options must be cloned when passed to createConnection.

### DIFF
--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -41,10 +41,10 @@ function Adapter() {
         throw err;
       }
 
-      this.db = mongoose.createConnection(connectionString, gooseOpt);
+      this.db = mongoose.createConnection(connectionString, _.cloneDeep(gooseOpt));
       this.db.on('error', handleDbError);
 
-      this.oplogDB = mongoose.createConnection(oplogConnectionString, gooseOpt);
+      this.oplogDB = mongoose.createConnection(oplogConnectionString, _.cloneDeep(gooseOpt));
       this.oplogDB.on('error', handleDbError);
     };
 


### PR DESCRIPTION
I was getting `MongoError: auth failed` when running code against old mongo version.

It turned out that there were 2 connections being created and the same options object has been passed to each call. The problem was that first call modified the options so second call was facing auth error.

```
this.db = mongoose.createConnection(connectionString, gooseOpt);
this.oplogDB = mongoose.createConnection(oplogConnectionString, gooseOpt);
```

Solution was to clone options before passing them to `createConnection`:

```
this.db = mongoose.createConnection(connectionString, _.cloneDeep(gooseOpt));
this.oplogDB = mongoose.createConnection(oplogConnectionString, _.cloneDeep(gooseOpt));
```
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/169?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/169'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>