### PR TITLE
bugfix/AGCMD-2046 SSE Updates do not include data

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -311,7 +311,10 @@ SSE.prototype.getData = function(routeName, chunk) {
 
     switch (chunk.op) {
         case 'i' : data = this.harvesterApp.adapter._deserialize(model, chunk.o); break;
-        case 'u' : data = chunk.o.$set; break;
+        case 'u' :
+            data = chunk.o.$set || chunk.o;
+            data._id = chunk.o2._id;
+            break;
         default : data = {}
     }
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/agco/harvesterjs/pull/171%23discussion_r54104772%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/171%23discussion_r54108805%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/171%23issuecomment-189331844%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20f89ff460eb9091a79bdfdca2351ac0340bcc0352%20test/singleRouteSSE.spec.js%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/171%23discussion_r54104772%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3F%20why%20this%20change%3F%22%2C%20%22created_at%22%3A%20%222016-02-25T14%3A47%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%2C%20%7B%22body%22%3A%20%22With%20%601%60%20this%20test%20leve%20%60it%60%20too%20early%20and%20actully%20didn%27t%20test%20what%20it%20should%20test%22%2C%20%22created_at%22%3A%20%222016-02-25T15%3A10%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7689681%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jbeynar%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/singleRouteSSE.spec.js%3AL185-246%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/171%23issuecomment-189331844%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Tests%20are%20passing%20on%20my%20env%20so%20I%27m%20merging%20this.%22%2C%20%22created_at%22%3A%20%222016-02-26T15%3A46%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/431064%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/blabno%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull f89ff460eb9091a79bdfdca2351ac0340bcc0352 test/singleRouteSSE.spec.js 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/171#discussion_r54104772'>File: test/singleRouteSSE.spec.js:L185-246</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars.githubusercontent.com/u/372075?v=3' height=16 width=16'></a> ? why this change?
- <a href='https://github.com/jbeynar'><img border=0 src='https://avatars.githubusercontent.com/u/7689681?v=3' height=16 width=16'></a> With `1` this test leve `it` too early and actully didn't test what it should test
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/171#issuecomment-189331844'>General Comment</a></b>
- <a href='https://github.com/blabno'><img border=0 src='https://avatars.githubusercontent.com/u/431064?v=3' height=16 width=16'></a> Tests are passing on my env so I'm merging this.


<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/171?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/171?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/171'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>