### PR TITLE
Set timeout to false to prevent query from timing out

### DIFF
--- a/lib/events-reader.js
+++ b/lib/events-reader.js
@@ -89,7 +89,8 @@ module.exports = function (harvesterApp) {
                 , coll = db.collection('oplog.rs')
                 , options = {
                     tailable: true,
-                    awaitData: true
+                    awaitData: true,
+                    timeout: false
                 };
 
             time = {$gt: since};


### PR DESCRIPTION
The mongo log in production shows tons of reconnections for these queries. It also shows a large spike in CPU usage after about 10 minutes of inactivity.

This should fix that problem, and keep the tailable cursor open, as expected.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/agco/harvesterjs/pull/174%23issuecomment-216695137%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/174%23issuecomment-216695137%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/6037404/badge%29%5D%28https%3A//coveralls.io/builds/6037404%29%5Cn%5CnCoverage%20remained%20the%20same%20at%2083.628%25%20when%20pulling%20%2A%2Aad11534ec560af47a402a787a5934f94354e0b25%20on%20bugfix/oplogTimeout%2A%2A%20into%20%2A%2A552cdc7eb6aa53eee3a473e84a44a7196ea55b30%20on%20develop%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222016-05-03T23%3A25%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/174#issuecomment-216695137'>General Comment</a></b>
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/6037404/badge)](https://coveralls.io/builds/6037404)
Coverage remained the same at 83.628% when pulling **ad11534ec560af47a402a787a5934f94354e0b25 on bugfix/oplogTimeout** into **552cdc7eb6aa53eee3a473e84a44a7196ea55b30 on develop**.


<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/174?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/174?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/174'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/agco/harvesterjs/174)
<!-- Reviewable:end -->
***