### PR TITLE
Allow custom options for bodyParser middleware.

### DIFF
--- a/lib/harvester.js
+++ b/lib/harvester.js
@@ -113,7 +113,7 @@ Harvester.prototype._init = function (options) {
     router.use(allowCrossDomain(options.cors));
   }
   router.disable('x-powered-by');
-  router.use(bodyParser.json());
+  router.use(bodyParser.json(options.bodyParser));
 
 
   // Create a database adapter instance.

--- a/lib/send-error.js
+++ b/lib/send-error.js
@@ -25,6 +25,11 @@ var sendError = function (req, res, error) {
     function normaliseError(error) {
         if (error instanceof JSONAPI_Error) {
             return error;
+        } else if (error && error.status === 413) {
+            return new JSONAPI_Error({
+                status: 413,
+                detail: error && process.env.NODE_ENV !== 'production' ? error.toString() : ''
+            });
         } else {
             return new JSONAPI_Error({
                 status: 500,
@@ -41,7 +46,7 @@ var sendError = function (req, res, error) {
         }
 
         // handle each error
-        _.forEach(error, function A(error, index, collection) {
+        _.forEach(error, function A(error) {
             // This function is `A` as it's a "throwaway" (anonymous) function,
             // but anonymous functions make stack traces harder to read. There
             // exists a convention used by some (myself included) to name such

--- a/test/bodyParserConfiguration.spec.js
+++ b/test/bodyParserConfiguration.spec.js
@@ -1,0 +1,77 @@
+var _ = require('lodash');
+var expect = require('chai').expect;
+var supertest = require('supertest');
+var harvester = require('../lib/harvester');
+var config = require('./config.js');
+
+function configureApp(options, port) {
+    var harvesterApp = harvester(options);
+    harvesterApp.router.post('/hugebody', function (req, res) {
+        res.send();
+    });
+    harvesterApp.listen(port);
+    return harvesterApp;
+}
+
+describe('bodyParser configuration', function () {
+
+    var payload100kb;
+    var payload200kb;
+    var payload300kb;
+
+    before(function () {
+        var surroundingJsonStringLength = 8;
+        payload100kb = JSON.stringify({a: _.fill(new Array(100000 - surroundingJsonStringLength), 'a').join('')});
+        payload200kb = JSON.stringify({a: _.fill(new Array(200000 - surroundingJsonStringLength), 'a').join('')});
+        payload300kb = JSON.stringify({a: _.fill(new Array(300000 - surroundingJsonStringLength), 'a').join('')});
+        expect(Buffer.byteLength(payload100kb)).to.equal(100000);
+        expect(Buffer.byteLength(payload200kb)).to.equal(200000);
+        expect(Buffer.byteLength(payload300kb)).to.equal(300000);
+    });
+
+    describe('when body parser configuration is not provided in options', function () {
+        var baseUrl;
+
+        before(function () {
+            var options = _.cloneDeep(config.harvester.options);
+            delete options.bodyParser;
+            var port = 8002;
+            this.harvesterApp = configureApp(options, port);
+            baseUrl = 'http://localhost:' + port;
+        });
+
+        describe('and request payload is 100kb', function () {
+            it('should respond with 200', function (done) {
+                supertest(baseUrl).post('/hugebody').set('Content-type', 'application/json').send(payload100kb).expect(200).end(done);
+            });
+        });
+
+        describe('and request payload is above 100kb', function () {
+            it('should respond with 413 entity too large', function (done) {
+                supertest(baseUrl).post('/hugebody').set('Content-type', 'application/json').send(payload200kb).expect(413).end(done);
+            });
+        });
+    });
+    describe('when body parser configuration is provided in options with limit set to 200kb', function () {
+        var baseUrl;
+
+        before(function () {
+            var options = _.cloneDeep(config.harvester.options);
+            options.bodyParser = {limit: '200kb'};
+            var port = 8003;
+            this.harvesterApp = configureApp(options, port);
+            baseUrl = 'http://localhost:' + port;
+        });
+
+        describe('and request payload is 200kb', function () {
+            it('should respond with 200', function (done) {
+                supertest(baseUrl).post('/hugebody').set('Content-type', 'application/json').send(payload200kb).expect(200).end(done);
+            });
+        });
+        describe('and request payload is above 200kb', function () {
+            it('should respond with 413 entity too large', function (done) {
+                supertest(baseUrl).post('/hugebody').set('Content-type', 'application/json').send(payload300kb).expect(413).end(done);
+            });
+        });
+    });
+});

--- a/test/events-reader.spec.js
+++ b/test/events-reader.spec.js
@@ -188,13 +188,14 @@ describe('onChange callback, event capture and at-least-once delivery semantics'
         });
 
         afterEach(function (done) {
-            this.eventsReader.stop()
-                .then(function () {
-                    done();
-                })
-                .catch(function (err) {
-                    done(err);
-                });
+            var that = this;
+            Promise.delay(1000).then(function () {
+                that.eventsReader.stop()
+                    .then(function () {
+                        done();
+                    })
+                    .catch(done);
+            });
         });
 
         describe('When a new post is added', function () {


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/agco/harvesterjs/pull/175%23issuecomment-245889148%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/175%23issuecomment-245889241%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/175%23issuecomment-245890747%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/175%23issuecomment-245889148%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/7814847/badge%29%5D%28https%3A//coveralls.io/builds/7814847%29%5Cn%5CnCoverage%20increased%20%28%2B0.03%25%29%20to%2083.551%25%20when%20pulling%20%2A%2Abf93e2c125d31690dda60043a9f69933292be71d%20on%20feature/configurable-body-parser%2A%2A%20into%20%2A%2A60f16d9808d918a1ecf255f4c29cf57478961016%20on%20master%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222016-09-09T11%3A34%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/7814851/badge%29%5D%28https%3A//coveralls.io/builds/7814851%29%5Cn%5CnCoverage%20increased%20%28%2B0.03%25%29%20to%2083.551%25%20when%20pulling%20%2A%2Abf93e2c125d31690dda60043a9f69933292be71d%20on%20feature/configurable-body-parser%2A%2A%20into%20%2A%2A60f16d9808d918a1ecf255f4c29cf57478961016%20on%20master%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222016-09-09T11%3A34%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20delay%20looks%20a%20bit%20dodgy%20of%20course%2C%20but%20given%20time%20constraints%20I%27m%20ok%20merging%20it%20now.%20We%20should%20have%20some%20RCA%20afterwards%20though.%22%2C%20%22created_at%22%3A%20%222016-09-09T11%3A43%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/666156%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kristofsajdak%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/175#issuecomment-245889148'>General Comment</a></b>
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/7814847/badge)](https://coveralls.io/builds/7814847)
Coverage increased (+0.03%) to 83.551% when pulling **bf93e2c125d31690dda60043a9f69933292be71d on feature/configurable-body-parser** into **60f16d9808d918a1ecf255f4c29cf57478961016 on master**.
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/7814851/badge)](https://coveralls.io/builds/7814851)
Coverage increased (+0.03%) to 83.551% when pulling **bf93e2c125d31690dda60043a9f69933292be71d on feature/configurable-body-parser** into **60f16d9808d918a1ecf255f4c29cf57478961016 on master**.
- <a href='https://github.com/kristofsajdak'><img border=0 src='https://avatars.githubusercontent.com/u/666156?v=3' height=16 width=16'></a> The delay looks a bit dodgy of course, but given time constraints I'm ok merging it now. We should have some RCA afterwards though.


<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/175?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/175?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/175'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/agco/harvesterjs/175)
<!-- Reviewable:end -->
***
***
***