### PR TITLE
Change debug message tu use full body instead of just timestamp

### DIFF
--- a/lib/events-reader-checkpoint-writer.js
+++ b/lib/events-reader-checkpoint-writer.js
@@ -17,7 +17,7 @@ const persistLastCheckpoint = () => {
   if(lastDoc && lastCheckpointId) {
     harvesterApp.adapter.update('checkpoint', lastCheckpointId, {ts: lastDoc.ts})
       .then(checkpoint => {
-        debug('last written checking point ' + checkpoint.ts);
+        debug('last written checking point ' + JSON.stringify(checkpoint));
       })
       .catch(error => {
         console.log(error);


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/agco/harvesterjs/pull/204%23issuecomment-289526095%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/204%23issuecomment-289527733%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/204%23issuecomment-289526095%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/10793012/badge%29%5D%28https%3A//coveralls.io/builds/10793012%29%5Cn%5CnCoverage%20remained%20the%20same%20at%2084.164%25%20when%20pulling%20%2A%2A6a99b4a5d1ea34630a3a7d394443293764017d96%20on%20change-debug-message%2A%2A%20into%20%2A%2A36a9bff55d20c971de144b5a9585b82c9bfef4b8%20on%20develop%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222017-03-27T17%3A33%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM.%22%2C%20%22created_at%22%3A%20%222017-03-27T17%3A39%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars0.githubusercontent.com/u/2266929%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Juraci%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/204#issuecomment-289526095'>General Comment</a></b>
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars2.githubusercontent.com/u/2354108?v=3' height=16 width=16></a> [![Coverage Status](https://coveralls.io/builds/10793012/badge)](https://coveralls.io/builds/10793012)
Coverage remained the same at 84.164% when pulling **6a99b4a5d1ea34630a3a7d394443293764017d96 on change-debug-message** into **36a9bff55d20c971de144b5a9585b82c9bfef4b8 on develop**.
- <a href='https://github.com/Juraci'><img border=0 src='https://avatars0.githubusercontent.com/u/2266929?v=3' height=16 width=16></a> LGTM.


<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/204?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/204?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/204'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/agco/harvesterjs/204)
<!-- Reviewable:end -->
***
***