### PR TITLE
Hotfix/remove patch

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -85,14 +85,6 @@ function route(harvester, name, model, schema, routeOptions) {
         notAllowed : true
     });
 
-    this.patch = new RouteMethod({
-        resource: _this,
-        harvester: harvester,
-        method : 'patch',
-        route : collectionRoute,
-        notAllowed : true
-    });
-
     this.getById = new RouteMethod({
         resource: _this,
         harvester: harvester,
@@ -118,15 +110,6 @@ function route(harvester, name, model, schema, routeOptions) {
         method : 'delete',
         route: individualRoute,
         permissionSuffix: 'deleteById'
-    });
-
-    this.patchById = new RouteMethod({
-        resource: _this,
-        harvester: harvester,
-        handlers : this.fnHandlers,
-        method : 'patch',
-        route: individualRoute,
-        permissionSuffix: 'patchById'
     });
 
     this.getChangeEventsStreaming = new RouteMethod({
@@ -541,7 +524,6 @@ function route(harvester, name, model, schema, routeOptions) {
      * Handle unsupported methods on a collection of resources.
      */
     this.put().register();
-    this.patch().register();
     this.delete().register();
 
     /*
@@ -799,7 +781,6 @@ function route(harvester, name, model, schema, routeOptions) {
 
     this.getById().register();
     this.putById().register();
-    this.patchById().register();
     this.deleteById().register();
 
     /*
@@ -860,15 +841,15 @@ function route(harvester, name, model, schema, routeOptions) {
     }
 
     this.readOnly = function () {
-        disallow(['post', 'putById', 'deleteById', 'patchById']);
+        disallow(['post', 'putById', 'deleteById']);
     };
 
     this.restricted = function () {
-        disallow(['post', 'putById', 'deleteById', 'patchById', 'get', 'getById']);
+        disallow(['post', 'putById', 'deleteById', 'get', 'getById']);
     };
 
     this.immutable = function () {
-        disallow(['putById', 'deleteById', 'patchById']);
+        disallow(['putById', 'deleteById']);
     };
 
     return this;
@@ -899,7 +880,7 @@ function getAssociations(schema, options) {
 }
 
 route.getRouteMethodNames = function () {
-    return ['get', 'post', 'put', 'delete', 'patch', 'getById', 'putById', 'deleteById', 'patchById', 'getChangeEventsStreaming'];
+    return ['get', 'post', 'put', 'delete', 'getById', 'putById', 'deleteById', 'getChangeEventsStreaming'];
 };
 
 /*

--- a/test/associations.spec.js
+++ b/test/associations.spec.js
@@ -45,22 +45,6 @@ describe('associations', function () {
                     done();
                 });
             });
-
-        it('should be able to dissociate', function (done) {
-            request(config.baseUrl)
-                .patch('/people/' + ids.people[0])
-                .send([
-                    {path: '/people/0/links/pets', op: 'replace', value: []}
-                ])
-                .expect('Content-Type', /json/)
-                .expect(200)
-                .end(function (error, response) {
-                    should.not.exist(error);
-                    var body = JSON.parse(response.text);
-                    should.not.exist(body.people[0].links);
-                    done();
-                });
-        });
     });
 
     describe('one to many association', function () {
@@ -86,21 +70,6 @@ describe('associations', function () {
                     should.not.exist(error);
                     var body = JSON.parse(response.text);
                     should.equal(body.pets[0].links.owner, ids.people[0]);
-                    done();
-                });
-        });
-        it('should be able to dissociate', function (done) {
-            request(config.baseUrl)
-                .patch('/pets/' + ids.pets[0])
-                .send([
-                    {path: '/pets/0/links/owner', op: 'replace', value: null}
-                ])
-                .expect('Content-Type', /json/)
-                .expect(200)
-                .end(function (error, response) {
-                    should.not.exist(error);
-                    var body = JSON.parse(response.text);
-                    should.not.exist(body.pets[0].links);
                     done();
                 });
         });
@@ -132,21 +101,6 @@ describe('associations', function () {
                     done();
                 });
         });
-        it('should be able to dissociate', function (done) {
-            request(config.baseUrl)
-                .patch('/people/' + ids.people[0])
-                .send([
-                    {path: '/people/0/links/soulmate', op: 'replace', value: null}
-                ])
-                .expect('Content-Type', /json/)
-                .expect(200)
-                .end(function (error, response) {
-                    should.not.exist(error);
-                    var body = JSON.parse(response.text);
-                    should.not.exist(body.people[0].links);
-                    done();
-                });
-        });
     });
 
     describe('many to many association', function () {
@@ -172,21 +126,6 @@ describe('associations', function () {
                     should.not.exist(error);
                     var body = JSON.parse(response.text);
                     (body.people[0].links.lovers).should.containEql(ids.people[1]);
-                    done();
-                });
-        });
-        it('should be able to dissociate', function (done) {
-            request(config.baseUrl)
-                .patch('/people/' + ids.people[0])
-                .send([
-                    {path: '/people/0/links/lovers', op: 'replace', value: []}
-                ])
-                .expect('Content-Type', /json/)
-                .expect(200)
-                .end(function (error, response) {
-                    should.not.exist(error);
-                    var body = JSON.parse(response.text);
-                    should.not.exist(body.people[0].links);
                     done();
                 });
         });

--- a/test/chaining.spec.js
+++ b/test/chaining.spec.js
@@ -25,7 +25,7 @@ describe('chaining', function () {
                 }
             });
 
-            ['get', 'post', 'put', 'delete', 'patch', 'getById', 'putById', 'deleteById', 'patchById', 'getChangeEventsStreaming'
+            ['get', 'post', 'put', 'delete', 'getById', 'putById', 'deleteById', 'getChangeEventsStreaming'
             ].forEach(function (httpMethod) {
                     should.exist(plant[httpMethod]().before);
                     should.exist(plant[httpMethod]().after);

--- a/test/exportPermissions.spec.js
+++ b/test/exportPermissions.spec.js
@@ -19,7 +19,7 @@ describe('Export permissions', function () {
     it('should export 14 permissions, excluding disallowed ones', function () {
         var expectedPermissions = [
             'person.get', 'person.getById', 'person.getChangeEventsStreaming',
-            'pet.get', 'pet.post', 'pet.getById', 'pet.putById', 'pet.deleteById', 'pet.patchById', 'pet.getChangeEventsStreaming',
+            'pet.get', 'pet.post', 'pet.getById', 'pet.putById', 'pet.deleteById', 'pet.getChangeEventsStreaming',
             'user.get', 'user.post', 'user.getById', 'user.getChangeEventsStreaming'
         ];
         var exportedPermissions = harvesterInstance.exportPermissions();

--- a/test/immutable.spec.js
+++ b/test/immutable.spec.js
@@ -59,18 +59,4 @@ describe('Immutable', function () {
         });
     });
 
-    it('should NOT be possible to patchById', function (done) {
-        var data = [
-            {
-                op: 'replace',
-                path: '/immutables/0/name',
-                value: 'Baba Jaga'
-            }
-        ];
-        supertest(config.baseUrl).patch('/immutables/' + ids.immutables[0]).send(data).expect('Content-Type', /json/).expect(405).end(function (error) {
-            should.not.exist(error);
-            done();
-        });
-    });
-
 });

--- a/test/includes.spec.js
+++ b/test/includes.spec.js
@@ -13,30 +13,36 @@ describe("includes", function () {
     function setupLinks(_ids) {
         ids = _ids;
 
-        function link(url, path, value) {
+        function link(resource, resourceId, link, linkId) {
+          const url = `/${resource}/${resourceId}`;
+
             return new Promise(function (resolve) {
-                var data = [
-                    {
-                        op: 'replace',
-                        path: path,
-                        value: value
+              var data = {
+                [resource]: [
+                  {
+                    links: {
+                      [link]: linkId
                     }
-                ];
-                request(config.baseUrl).patch(url).set('Content-Type', 'application/json').send(JSON.stringify(data)).end(function (err) {
+                  }
+                ]
+              };
+                request(config.baseUrl).put(url).set('Content-Type', 'application/json').send(JSON.stringify(data)).end(function (err, res) {
+
+                    (res.statusCode).should.be.equal(200);
                     should.not.exist(err);
                     setTimeout(resolve, 100);//sometimes tests fail if resolve is called immediately, probably mongo has problems indexing concurrently
                 });
             });
         }
 
-        return Promise.all([
-            link('/people/' + ids.people[0], '/people/0/soulmate', ids.people[1]), //TODO: harvester should take care about this on its own
-            link('/people/' + ids.people[1], '/people/0/soulmate', ids.people[0]),
-            link('/people/' + ids.people[0], '/people/0/lovers', [ids.people[1]]),
-            link('/pets/' + ids.pets[0], '/pets/0/owner', [ids.people[0]]),
-            link('/pets/' + ids.pets[0], '/pets/0/food', [ids.foobars[0]]),
-            link('/collars/' + ids.collars[0], '/collars/0/collarOwner', [ids.pets[0]])
-        ])
+      return Promise.all([
+        link('people', ids.people[0], 'soulmate', ids.people[1]),
+        link('people', ids.people[1], 'soulmate', ids.people[0]),
+        link('people', ids.people[0], 'lovers', [ids.people[1]]),
+        link('pets', ids.pets[0], 'owner', ids.people[0]),
+        link('pets', ids.pets[0], 'food', ids.foobars[0]),
+        link('collars', ids.collars[0], 'collarOwner', ids.pets[0])
+      ]);
     }
 
     beforeEach(function () {

--- a/test/readOnly.spec.js
+++ b/test/readOnly.spec.js
@@ -72,18 +72,4 @@ describe('ReadOnly', function () {
         });
     });
 
-    it('should NOT be possible to patchById', function (done) {
-        var data = [
-            {
-                op: 'replace',
-                path: '/readers/0/name',
-                value: 'Baba Jaga'
-            }
-        ];
-        supertest(config.baseUrl).patch('/readers/' + ids.readers[0]).send(data).expect('Content-Type', /json/).expect(405).end(function (error) {
-            should.not.exist(error);
-            done();
-        });
-    });
-
 });

--- a/test/remoteIncludes.spec.js
+++ b/test/remoteIncludes.spec.js
@@ -116,10 +116,10 @@ describe('remote link', function () {
                     that.commentId = body.comments[0].id;
                     return $http({
                         uri: app1BaseUrl + '/posts/' + that.postId,
-                        method: 'PATCH',
-                        json: [{op: 'replace', path: 'posts/0/links/comments', value: [that.commentId]}]
+                        method: 'PUT',
+                        json: {posts: [{links: {comments: [that.commentId]}}]}
                     });
-                });
+                })
         });
 
         describe('fetch posts and include author', function () {

--- a/test/restricted.spec.js
+++ b/test/restricted.spec.js
@@ -60,18 +60,4 @@ describe('Restricted', function () {
         });
     });
 
-    it('should NOT be possible to patchById', function (done) {
-        var data = [
-            {
-                op: 'replace',
-                path: '/restricts/0/name',
-                value: 'Baba Jaga'
-            }
-        ];
-        supertest(config.baseUrl).patch('/restricts/' + 1).send(data).expect('Content-Type', /json/).expect(405).end(function (error) {
-            should.not.exist(error);
-            done();
-        });
-    });
-
 });

--- a/test/roles.spec.js
+++ b/test/roles.spec.js
@@ -57,10 +57,10 @@ describe('Roles', function () {
     describe('having specific config, exportRoles', function () {
         it('should return proper roles descriptor', function () {
             var expectedDescriptor = {
-                Admin: ['person.get', 'person.post', 'person.getById', 'person.putById', 'person.deleteById', 'person.patchById',
-                        'person.getChangeEventsStreaming', 'user.get', 'user.post', 'user.putById', 'user.deleteById', 'user.patchById',
+                Admin: ['person.get', 'person.post', 'person.getById', 'person.putById', 'person.deleteById',
+                        'person.getChangeEventsStreaming', 'user.get', 'user.post', 'user.putById', 'user.deleteById',
                         'user.getChangeEventsStreaming'],
-                SuperAdmin: ['user.get', 'user.post', 'user.putById', 'user.deleteById', 'user.patchById', 'user.getChangeEventsStreaming'],
+                SuperAdmin: ['user.get', 'user.post', 'user.putById', 'user.deleteById', 'user.getChangeEventsStreaming'],
                 Moderator: ['user.getById']
             };
             harvesterInstance.exportRoles().should.eql(expectedDescriptor);
@@ -107,20 +107,6 @@ describe('Roles', function () {
                 .expect(200)
                 .end(done);
         });
-        it('should be allowed to patch person by id', function (done) {
-            var patch = [
-                {
-                    op: 'replace',
-                    path: '/people/0/name',
-                    value: 'Josephine'
-                }
-            ];
-            request(baseUrl)
-                .patch('/people/' + personId)
-                .send(patch)
-                .expect(200)
-                .end(done);
-        });
         it.skip('should be allowed to getChangeEventsStreaming for person', function () {
             throw new Error('Not implemented yet');
         });
@@ -153,20 +139,6 @@ describe('Roles', function () {
                 .send({users: [
                     {name: 'Joseph'}
                 ]})
-                .expect(200)
-                .end(done);
-        });
-        it('should be allowed to patch user by id', function (done) {
-            var patch = [
-                {
-                    op: 'replace',
-                    path: '/users/0/name',
-                    value: 'Josephine'
-                }
-            ];
-            request(baseUrl)
-                .patch('/users/' + userId)
-                .send(patch)
                 .expect(200)
                 .end(done);
         });
@@ -204,20 +176,6 @@ describe('Roles', function () {
                 ]})
                 .expect(200).
                 end(done);
-        });
-        it('should be allowed to patch pet by id', function (done) {
-            var patch = [
-                {
-                    op: 'replace',
-                    path: '/pets/0/name',
-                    value: 'Josephine'
-                }
-            ];
-            request(baseUrl)
-                .patch('/pets/' + petId)
-                .send(patch)
-                .expect(200)
-                .end(done);
         });
         it.skip('should be allowed to getChangeEventsStreaming for pet', function () {
             throw new Error('Not implemented yet');
@@ -264,20 +222,6 @@ describe('Roles', function () {
                 .expect(403)
                 .end(done);
         });
-        it('should NOT be allowed to patch person by id', function (done) {
-            var patch = [
-                {
-                    op: 'replace',
-                    path: '/people/0/name',
-                    value: 'Josephine'
-                }
-            ];
-            request(baseUrl)
-                .patch('/people/' + personId)
-                .send(patch)
-                .expect(403)
-                .end(done);
-        });
         it.skip('should NOT be allowed to getChangeEventsStreaming for person', function () {
             throw new Error('Not implemented yet');
         });
@@ -313,20 +257,6 @@ describe('Roles', function () {
                 .expect(200)
                 .end(done);
         });
-        it('should be allowed to patch user by id', function (done) {
-            var patch = [
-                {
-                    op: 'replace',
-                    path: '/users/0/name',
-                    value: 'Josephine'
-                }
-            ];
-            request(baseUrl)
-                .patch('/users/' + userId)
-                .send(patch)
-                .expect(200)
-                .end(done);
-        });
         it.skip('should be allowed to getChangeEventsStreaming for user', function () {
             throw new Error('Not implemented yet');
         });
@@ -359,20 +289,6 @@ describe('Roles', function () {
                 .send({pets: [
                     {name: 'Joseph'}
                 ]})
-                .expect(200)
-                .end(done);
-        });
-        it('should be allowed to patch pet by id', function (done) {
-            var patch = [
-                {
-                    op: 'replace',
-                    path: '/pets/0/name',
-                    value: 'Josephine'
-                }
-            ];
-            request(baseUrl)
-                .patch('/pets/' + petId)
-                .send(patch)
                 .expect(200)
                 .end(done);
         });
@@ -421,20 +337,6 @@ describe('Roles', function () {
                 .expect(403)
                 .end(done);
         });
-        it('should NOT be allowed to patch person by id', function (done) {
-            var patch = [
-                {
-                    op: 'replace',
-                    path: '/people/0/name',
-                    value: 'Josephine'
-                }
-            ];
-            request(baseUrl)
-                .patch('/people/' + personId)
-                .send(patch)
-                .expect(403)
-                .end(done);
-        });
         it.skip('should NOT be allowed to getChangeEventsStreaming for person', function () {
             throw new Error('Not implemented yet');
         });
@@ -470,20 +372,6 @@ describe('Roles', function () {
                 .expect(403)
                 .end(done);
         });
-        it('should NOT be allowed to patch user by id', function (done) {
-            var patch = [
-                {
-                    op: 'replace',
-                    path: '/users/0/name',
-                    value: 'Josephine'
-                }
-            ];
-            request(baseUrl)
-                .patch('/users/' + userId)
-                .send(patch)
-                .expect(403)
-                .end(done);
-        });
         it.skip('should NOT be allowed to getChangeEventsStreaming for user', function () {
             throw new Error('Not implemented yet');
         });
@@ -516,20 +404,6 @@ describe('Roles', function () {
                 .send({pets: [
                     {name: 'Joseph'}
                 ]})
-                .expect(200)
-                .end(done);
-        });
-        it('should be allowed to patch pet by id', function (done) {
-            var patch = [
-                {
-                    op: 'replace',
-                    path: '/pets/0/name',
-                    value: 'Josephine'
-                }
-            ];
-            request(baseUrl)
-                .patch('/pets/' + petId)
-                .send(patch)
                 .expect(200)
                 .end(done);
         });


### PR DESCRIPTION
We are removing the PATCH support due the issue https://github.com/agco/harvesterjs/issues/203 .
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/agco/harvesterjs/pull/206%23issuecomment-289877880%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/206%23issuecomment-289879745%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/206%23discussion_r108524258%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/206%23discussion_r108525153%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/206%23discussion_r108525500%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/206%23issuecomment-289921562%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/206%23issuecomment-289877880%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/10815734/badge%29%5D%28https%3A//coveralls.io/builds/10815734%29%5Cn%5CnCoverage%20decreased%20%28-1.5%25%29%20to%2082.699%25%20when%20pulling%20%2A%2Ab4d257e26666cab40b5d793a9d7ce332d5a52854%20on%20hotfix/remove-patch%2A%2A%20into%20%2A%2A6bd13dfa81c645dda12262791c4638f356fa6cab%20on%20develop%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222017-03-28T19%3A25%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/10815852/badge%29%5D%28https%3A//coveralls.io/builds/10815852%29%5Cn%5CnCoverage%20decreased%20%28-1.5%25%29%20to%2082.699%25%20when%20pulling%20%2A%2Ab4d257e26666cab40b5d793a9d7ce332d5a52854%20on%20hotfix/remove-patch%2A%2A%20into%20%2A%2A6bd13dfa81c645dda12262791c4638f356fa6cab%20on%20develop%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222017-03-28T19%3A32%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%22%2C%20%22created_at%22%3A%20%222017-03-28T22%3A15%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20b4d257e26666cab40b5d793a9d7ce332d5a52854%20test/includes.spec.js%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/206%23discussion_r108524258%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20explain%20this%20change%3F%20It%20seems%20you%20followed%20an%20TODO%20comment%20that%20led%20you%20to%20this%20change.%22%2C%20%22created_at%22%3A%20%222017-03-28T20%3A08%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/10089668%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lucaslago%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20had%20to%20rewrite%20tests%20on%20which%20PATCH%20were%20used%20to%20use%20PUT%20instead%22%2C%20%22created_at%22%3A%20%222017-03-28T20%3A13%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/5835706%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/waldemarnt%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/includes.spec.js%3AL13-49%22%7D%2C%20%22Pull%20b4d257e26666cab40b5d793a9d7ce332d5a52854%20test/includes.spec.js%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/206%23discussion_r108525500%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Didn%27t%20change%20the%20test%20behaviour%2C%20it%27s%20passing%2C%20I%20just%20changed%20it%20to%20be%20an%20object%20as%20the%20PUT%20method%20expects.%22%2C%20%22created_at%22%3A%20%222017-03-28T20%3A14%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/5835706%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/waldemarnt%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/includes.spec.js%3AL13-49%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/206#issuecomment-289877880'>General Comment</a></b>
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars2.githubusercontent.com/u/2354108?v=3' height=16 width=16></a> [![Coverage Status](https://coveralls.io/builds/10815734/badge)](https://coveralls.io/builds/10815734)
Coverage decreased (-1.5%) to 82.699% when pulling **b4d257e26666cab40b5d793a9d7ce332d5a52854 on hotfix/remove-patch** into **6bd13dfa81c645dda12262791c4638f356fa6cab on develop**.
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars2.githubusercontent.com/u/2354108?v=3' height=16 width=16></a> [![Coverage Status](https://coveralls.io/builds/10815852/badge)](https://coveralls.io/builds/10815852)
Coverage decreased (-1.5%) to 82.699% when pulling **b4d257e26666cab40b5d793a9d7ce332d5a52854 on hotfix/remove-patch** into **6bd13dfa81c645dda12262791c4638f356fa6cab on develop**.
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars3.githubusercontent.com/u/372075?v=3' height=16 width=16></a> LGTM
- [ ] <a href='#crh-comment-Pull b4d257e26666cab40b5d793a9d7ce332d5a52854 test/includes.spec.js 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/206#discussion_r108524258'>File: test/includes.spec.js:L13-49</a></b>
- <a href='https://github.com/lucaslago'><img border=0 src='https://avatars1.githubusercontent.com/u/10089668?v=3' height=16 width=16></a> Could you explain this change? It seems you followed an TODO comment that led you to this change.
- <a href='https://github.com/waldemarnt'><img border=0 src='https://avatars1.githubusercontent.com/u/5835706?v=3' height=16 width=16></a> I had to rewrite tests on which PATCH were used to use PUT instead
- [ ] <a href='#crh-comment-Pull b4d257e26666cab40b5d793a9d7ce332d5a52854 test/includes.spec.js 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/206#discussion_r108525500'>File: test/includes.spec.js:L13-49</a></b>
- <a href='https://github.com/waldemarnt'><img border=0 src='https://avatars1.githubusercontent.com/u/5835706?v=3' height=16 width=16></a> Didn't change the test behaviour, it's passing, I just changed it to be an object as the PUT method expects.


<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/206?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/206?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/206'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/agco/harvesterjs/206)
<!-- Reviewable:end -->
***
***
***
***
***
***