### PR TITLE
Setup dockerized tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,13 @@ addons:
     - gcc-4.8
     - g++-4.8
 env:
-  - CXX=g++-4.8 DEBUG=events-reader MONGODB_URL=mongodb://127.0.0.1:27017/test OPLOG_MONGODB_URL=mongodb://127.0.0.1:27017/local
+  - CXX=g++-4.8
+services:
+  - docker
 before_script:
-  - mongo --version
-  - mkdir -p db/test
-  - mongod --port 27017 --dbpath db/test --replSet rs0 --oplogSize 20 --noprealloc --fork --smallfiles --logpath mongodb.log
-  - sleep 3
-  - mongo admin --eval 'printjson(rs.initiate());'
-  - sleep 20
-script: ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
+  - docker-compose -f docker-compose.test.yml up -d db
+  - docker-compose -f docker-compose.test.yml up initReplicaset
+script: docker-compose -f docker-compose.test.yml up test
 deploy:
   provider: npm
   email: developer@agcocorp.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,13 @@
 language: node_js
 node_js:
   - '4.2.0'
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-4.8
-    - g++-4.8
-env:
-  - CXX=g++-4.8
 services:
   - docker
 before_script:
   - docker-compose -f docker-compose.test.yml up -d db
   - docker-compose -f docker-compose.test.yml up initReplicaset
-script: docker-compose -f docker-compose.test.yml up test
+  - docker-compose -f docker-compose.test.yml build test
+script: docker-compose -f docker-compose.test.yml run test
 deploy:
   provider: npm
   email: developer@agcocorp.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:4.2.0
+
+ENV HOME=/home/app/
+
+COPY package.json $HOME/harvesterjs/
+
+WORKDIR $HOME/harvesterjs/
+
+RUN npm install --progress=false
+
+COPY . $HOME/harvesterjs/
+
+CMD ["npm", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ENV HOME=/home/app/
 
 COPY package.json $HOME/harvesterjs/
 
+COPY npm-shrinkwrap.json $HOME/harvesterjs/
+
 WORKDIR $HOME/harvesterjs/
 
 RUN npm install --progress=false

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -15,5 +15,3 @@ services:
   initReplicaset:
     image: mongo:2.4.14
     command: bash -c "sleep 3 && mongo admin --host db:27017 --eval 'printjson(rs.initiate());'"
-    links:
-      - db

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 services:
   test:
     build: .

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,10 +1,14 @@
-version: '3'
+version: '2'
 services:
   test:
     build: .
     command: bash -c "sleep 20 && npm test"
     depends_on:
       - db
+    environment:
+      - DEBUG=events-reader
+      - MONGODB_URL=mongodb://db:27017/test
+      - OPLOG_MONGODB_URL=mongodb://db:27017/local
   db:
     image: mongo:2.4.14
     command: mongod --replSet rs0 --oplogSize 20 --noprealloc  --smallfiles --nojournal

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,7 +6,7 @@ services:
     depends_on:
       - db
     environment:
-      - DEBUG=events-reader
+      - DEBUG=
       - MONGODB_URL=mongodb://db:27017/test
       - OPLOG_MONGODB_URL=mongodb://db:27017/local
   db:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  test:
+    build: .
+    command: bash -c "sleep 20 && npm test"
+    depends_on:
+      - db
+  db:
+    image: mongo:2.4.14
+    command: mongod --replSet rs0 --oplogSize 20 --noprealloc  --smallfiles --nojournal
+  initReplicaset:
+    image: mongo:2.4.14
+    command: bash -c "sleep 3 && mongo admin --host db:27017 --eval 'printjson(rs.initiate());'"
+    links:
+      - db

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/agco/harvesterjs"
   },
   "scripts": {
-    "test": "mocha",
+    "test": "mocha && npm run lint",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },

--- a/test/config.js
+++ b/test/config.js
@@ -7,10 +7,10 @@ module.exports = {
     port: harvesterPort,
     options: {
       adapter: 'mongodb',
-      connectionString: process.env.MONGODB_URL || "mongodb://db:27017/test",
+      connectionString: process.env.MONGODB_URL || 'mongodb://db:27017/test',
       db: process.env.MONGODB || 'test',
       inflect: true,
-      oplogConnectionString: (process.env.OPLOG_MONGODB_URL || "mongodb://db:27017/local") + '?slaveOk=true',
+      oplogConnectionString: (process.env.OPLOG_MONGODB_URL || 'mongodb://db:27017/local') + '?slaveOk=true',
     }
   }
 };

--- a/test/config.js
+++ b/test/config.js
@@ -7,10 +7,10 @@ module.exports = {
     port: harvesterPort,
     options: {
       adapter: 'mongodb',
-      connectionString: process.env.MONGODB_URL || 'mongodb://127.0.0.1:27017/test',
+      connectionString: process.env.MONGODB_URL || "mongodb://db:27017/test",
       db: process.env.MONGODB || 'test',
       inflect: true,
-      oplogConnectionString: (process.env.OPLOG_MONGODB_URL || 'mongodb://127.0.0.1:27017/local') + '?slaveOk=true',
-    },
-  },
+      oplogConnectionString: (process.env.OPLOG_MONGODB_URL || "mongodb://db:27017/local") + '?slaveOk=true',
+    }
+  }
 };

--- a/test/config.js
+++ b/test/config.js
@@ -7,10 +7,10 @@ module.exports = {
     port: harvesterPort,
     options: {
       adapter: 'mongodb',
-      connectionString: process.env.MONGODB_URL || 'mongodb://db:27017/test',
+      connectionString: process.env.MONGODB_URL || 'mongodb://127.0.0.1:27017/test',
       db: process.env.MONGODB || 'test',
       inflect: true,
-      oplogConnectionString: (process.env.OPLOG_MONGODB_URL || 'mongodb://db:27017/local') + '?slaveOk=true',
+      oplogConnectionString: (process.env.OPLOG_MONGODB_URL || 'mongodb://127.0.0.1:27017/local') + '?slaveOk=true',
     }
   }
 };

--- a/test/remoteIncludes.spec.js
+++ b/test/remoteIncludes.spec.js
@@ -10,11 +10,11 @@ let harvester = require('../lib/harvester');
 // listening on hard coded free ports and duplicating harvesterjs options is not very robust and DRY
 
 let harvesterOptions = {
-    adapter: 'mongodb',
-    connectionString: process.env.MONGODB_URL || 'mongodb://db:27017/testDB',
-    db: 'testDB',
-    inflect: true,
-    oplogConnectionString: (process.env.OPLOG_MONGODB_URL || 'mongodb://db:27017/local') + '?slaveOk=true'
+  adapter: 'mongodb',
+  connectionString: process.env.MONGODB_URL || 'mongodb://db:27017/testDB',
+  db: 'testDB',
+  inflect: true,
+  oplogConnectionString: (process.env.OPLOG_MONGODB_URL || 'mongodb://db:27017/local') + '?slaveOk=true'
 };
 
 describe('remote link', function() {

--- a/test/remoteIncludes.spec.js
+++ b/test/remoteIncludes.spec.js
@@ -10,11 +10,11 @@ let harvester = require('../lib/harvester');
 // listening on hard coded free ports and duplicating harvesterjs options is not very robust and DRY
 
 let harvesterOptions = {
-  adapter: 'mongodb',
-  connectionString: 'mongodb://127.0.0.1:27017/testDB',
-  db: 'testDB',
-  inflect: true,
-  oplogConnectionString: 'mongodb://127.0.0.1:27017/local?slaveOk=true',
+    adapter: 'mongodb',
+    connectionString: 'mongodb://db:27017/testDB',
+    db: 'testDB',
+    inflect: true,
+    oplogConnectionString: 'mongodb://db:27017/local?slaveOk=true'
 };
 
 describe('remote link', function() {
@@ -30,7 +30,7 @@ describe('remote link', function() {
     before(function() {
 
       var that = this;
-      that.timeout(100000);
+      that.timeout(20000);
 
       that.harvesterApp1 =
                 harvester(harvesterOptions)

--- a/test/remoteIncludes.spec.js
+++ b/test/remoteIncludes.spec.js
@@ -9,13 +9,7 @@ let harvester = require('../lib/harvester');
 // todo we need a better strategy to stand up test harvesterjs instances
 // listening on hard coded free ports and duplicating harvesterjs options is not very robust and DRY
 
-let harvesterOptions = {
-  adapter: 'mongodb',
-  connectionString: process.env.MONGODB_URL || 'mongodb://db:27017/testDB',
-  db: 'testDB',
-  inflect: true,
-  oplogConnectionString: (process.env.OPLOG_MONGODB_URL || 'mongodb://db:27017/local') + '?slaveOk=true'
-};
+const harvesterOptions = require('./config').harvester.options;
 
 describe('remote link', function() {
 

--- a/test/remoteIncludes.spec.js
+++ b/test/remoteIncludes.spec.js
@@ -11,10 +11,10 @@ let harvester = require('../lib/harvester');
 
 let harvesterOptions = {
     adapter: 'mongodb',
-    connectionString: 'mongodb://db:27017/testDB',
+    connectionString: process.env.MONGODB_URL || 'mongodb://db:27017/testDB',
     db: 'testDB',
     inflect: true,
-    oplogConnectionString: 'mongodb://db:27017/local?slaveOk=true'
+    oplogConnectionString: (process.env.OPLOG_MONGODB_URL || 'mongodb://db:27017/local') + '?slaveOk=true'
 };
 
 describe('remote link', function() {


### PR DESCRIPTION
This allows developers to run all tests inside a docker container, turning docker the only dependency needed to run our tests in local and CI environment.

- [x] reduce build time by ~1min 30s since we don't have to install GCC and compile packages in travis anymore.
- [x] make sure local and ci test runs on the same environment by using docker

To run all tests in a local dev machine with neither leaking state between test runs nor having to install and configure mongodb/replicaSet just make sure you have docker installed and run: 

`docker-compose -f docker-compose.test.yml up`

PS:

I had to remove coveralls integration due to this issue: https://github.com/lemurheavy/coveralls-public/issues/487

It seems coveralls and travisCI have this recurring problem, I think we can migrate to code climate or codeCov if we need a test coverage tool. But as of right now I value having an easy way to run tests in local environment more than that.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/agco/harvesterjs/pull/207%23discussion_r108725068%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/207%23discussion_r108772749%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/207%23discussion_r108773893%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/207%23discussion_r108775234%22%2C%20%22https%3A//github.com/agco/harvesterjs/pull/207%23issuecomment-290408882%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/207%23issuecomment-290408882%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22nice%20cleanup%20-%20looks%20good%20to%20me%21%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-03-30T13%3A22%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%208f92277b38133867f19c8d2e7aa096e78639cd91%20docker-compose.test.yml%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/207%23discussion_r108725068%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20not%20necessary%20in%20docker-compose%20v2%2C%20they%20are%20all%20part%20of%20the%20same%20network%22%2C%20%22created_at%22%3A%20%222017-03-29T16%3A35%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/5835706%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/waldemarnt%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20docker-compose.test.yml%3AL1-20%22%7D%2C%20%22Pull%20dc0f6889fca5a3aea9c2aecd8de6563e712c1e94%20test/remoteIncludes.spec.js%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/agco/harvesterjs/pull/207%23discussion_r108772749%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20familiar%20with%20db%20as%20shorthand%20-%20does%20that%20mean%20localhost%20-%20and%20will%20that%20play%20well%20with%20non-dockerized%20users%3F%22%2C%20%22created_at%22%3A%20%222017-03-29T20%3A01%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%2C%20%7B%22body%22%3A%20%22db%20is%20an%20alias%20for%20the%20container%20ip%20in%20which%20mongodb%20is%20running.%20It%20should%20play%20well%20with%20non-dockeried%20users%20as%20long%20as%20they%20pass%20their%20mongodb%20connection%20string%20to%20the%20MONGODB_URL%20env%20var.%22%2C%20%22created_at%22%3A%20%222017-03-29T20%3A06%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/10089668%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lucaslago%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20thats%20a%20big%20ask%2C%20since%20it%20works%20today%20without%20it.%20If%20db%20is%20not%20definied%20you%20should%20fall%20back%20to%20127.xxx%20or%20localhost.%20I%20prefer%20127%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-03-29T20%3A13%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/372075%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ssebro%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/remoteIncludes.spec.js%3AL11-21%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 8f92277b38133867f19c8d2e7aa096e78639cd91 docker-compose.test.yml 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/207#discussion_r108725068'>File: docker-compose.test.yml:L1-20</a></b>
- <a href='https://github.com/waldemarnt'><img border=0 src='https://avatars1.githubusercontent.com/u/5835706?v=3' height=16 width=16></a> This is not necessary in docker-compose v2, they are all part of the same network
- [x] <a href='#crh-comment-Pull dc0f6889fca5a3aea9c2aecd8de6563e712c1e94 test/remoteIncludes.spec.js 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/207#discussion_r108772749'>File: test/remoteIncludes.spec.js:L11-21</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars3.githubusercontent.com/u/372075?v=3' height=16 width=16></a> I'm not familiar with db as shorthand - does that mean localhost - and will that play well with non-dockerized users?
- <a href='https://github.com/lucaslago'><img border=0 src='https://avatars1.githubusercontent.com/u/10089668?v=3' height=16 width=16></a> db is an alias for the container ip in which mongodb is running. It should play well with non-dockeried users as long as they pass their mongodb connection string to the MONGODB_URL env var.
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars3.githubusercontent.com/u/372075?v=3' height=16 width=16></a> I think thats a big ask, since it works today without it. If db is not definied you should fall back to 127.xxx or localhost. I prefer 127
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/agco/harvesterjs/pull/207#issuecomment-290408882'>General Comment</a></b>
- <a href='https://github.com/ssebro'><img border=0 src='https://avatars3.githubusercontent.com/u/372075?v=3' height=16 width=16></a> nice cleanup - looks good to me!


<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/207?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/207?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/207'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/agco/harvesterjs/207)
<!-- Reviewable:end -->
***
***
***
***
***