### PR TITLE
Revert "updating mongodb dependency"

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,8 +10,8 @@ services:
       - MONGODB_URL=mongodb://db:27017/test
       - OPLOG_MONGODB_URL=mongodb://db:27017/local
   db:
-    image: mongo:3.4
+    image: mongo:2.4.14
     command: mongod --replSet rs0 --oplogSize 20 --noprealloc  --smallfiles --nojournal
   initReplicaset:
-    image: mongo:3.4
+    image: mongo:2.4.14
     command: bash -c "sleep 3 && mongo admin --host db:27017 --eval 'printjson(rs.initiate());'"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,538 +2,933 @@
   "name": "harvesterjs",
   "version": "2.4.0",
   "dependencies": {
-    "accepts": {
-      "version": "1.0.7",
-      "from": "accepts@>=1.0.7 <1.1.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz"
-    },
     "agco-logger": {
       "version": "1.0.0",
       "from": "git+https://github.com/agco/agco-logger.git#c14fba9712968a0509bbf2c69c33a167a6cc1b07",
-      "resolved": "git+https://github.com/agco/agco-logger.git#c14fba9712968a0509bbf2c69c33a167a6cc1b07"
-    },
-    "ajv": {
-      "version": "4.11.5",
-      "from": "ajv@>=4.9.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz"
-    },
-    "asn1": {
-      "version": "0.2.3",
-      "from": "asn1@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-    },
-    "assert-plus": {
-      "version": "0.2.0",
-      "from": "assert-plus@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-    },
-    "async": {
-      "version": "1.0.0",
-      "from": "async@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "from": "asynckit@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-    },
-    "aws-sign2": {
-      "version": "0.6.0",
-      "from": "aws-sign2@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "from": "aws4@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "optional": true
+      "resolved": "git+https://github.com/agco/agco-logger.git#c14fba9712968a0509bbf2c69c33a167a6cc1b07",
+      "dependencies": {
+        "winston": {
+          "version": "2.3.1",
+          "from": "winston@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
+          "dependencies": {
+            "async": {
+              "version": "1.0.0",
+              "from": "async@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
+            },
+            "colors": {
+              "version": "1.0.3",
+              "from": "colors@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+            },
+            "cycle": {
+              "version": "1.0.3",
+              "from": "cycle@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+            },
+            "eyes": {
+              "version": "0.1.8",
+              "from": "eyes@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "stack-trace": {
+              "version": "0.0.9",
+              "from": "stack-trace@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+            }
+          }
+        }
+      }
     },
     "bluebird": {
-      "version": "2.11.0",
-      "from": "bluebird@>=2.9.27 <3.0.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz"
+      "version": "2.10.2",
+      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
     },
     "body-parser": {
       "version": "1.4.3",
-      "from": "body-parser@>=1.4.3 <1.5.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.4.3.tgz"
-    },
-    "boom": {
-      "version": "2.10.1",
-      "from": "boom@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-    },
-    "bson": {
-      "version": "1.0.4",
-      "from": "bson@>=1.0.4 <1.1.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz"
-    },
-    "buffer-crc32": {
-      "version": "0.2.3",
-      "from": "buffer-crc32@0.2.3",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz"
-    },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-    },
-    "bytes": {
-      "version": "1.0.0",
-      "from": "bytes@1.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "from": "caseless@>=0.12.0 <0.13.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
-    },
-    "co": {
-      "version": "4.6.0",
-      "from": "co@>=4.6.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
-    },
-    "colors": {
-      "version": "1.0.3",
-      "from": "colors@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-    },
-    "combined-stream": {
-      "version": "1.0.5",
-      "from": "combined-stream@>=1.0.5 <1.1.0",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-    },
-    "cookie": {
-      "version": "0.1.2",
-      "from": "cookie@0.1.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
-    },
-    "cookie-signature": {
-      "version": "1.0.4",
-      "from": "cookie-signature@1.0.4",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz"
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-    },
-    "create-error": {
-      "version": "0.3.1",
-      "from": "create-error@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/create-error/-/create-error-0.3.1.tgz"
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "from": "cryptiles@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-    },
-    "cycle": {
-      "version": "1.0.3",
-      "from": "cycle@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "from": "dashdash@>=1.12.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.4.3.tgz",
       "dependencies": {
-        "assert-plus": {
+        "bytes": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "from": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+        },
+        "depd": {
+          "version": "0.3.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-0.3.0.tgz"
+        },
+        "iconv-lite": {
+          "version": "0.4.3",
+          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.3.tgz"
+        },
+        "media-typer": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz"
+        },
+        "qs": {
+          "version": "0.6.6",
+          "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+        },
+        "raw-body": {
+          "version": "1.2.2",
+          "from": "https://registry.npmjs.org/raw-body/-/raw-body-1.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.2.2.tgz"
+        },
+        "type-is": {
+          "version": "1.3.1",
+          "from": "https://registry.npmjs.org/type-is/-/type-is-1.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.3.1.tgz",
+          "dependencies": {
+            "mime-types": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.0.tgz"
+            }
+          }
         }
       }
     },
     "debounce-promise": {
       "version": "3.0.1",
-      "from": "debounce-promise@>=3.0.1 <4.0.0",
+      "from": "https://registry.npmjs.org/debounce-promise/-/debounce-promise-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/debounce-promise/-/debounce-promise-3.0.1.tgz"
     },
     "debug": {
-      "version": "2.6.3",
-      "from": "debug@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz"
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "from": "delayed-stream@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-    },
-    "depd": {
-      "version": "0.3.0",
-      "from": "depd@0.3.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-0.3.0.tgz"
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "optional": true
-    },
-    "ee-first": {
-      "version": "1.0.3",
-      "from": "ee-first@1.0.3",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
-    },
-    "es6-promise": {
-      "version": "3.2.1",
-      "from": "es6-promise@3.2.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
-    },
-    "escape-html": {
-      "version": "1.0.1",
-      "from": "escape-html@1.0.1",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+      "version": "2.2.0",
+      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "dependencies": {
+        "ms": {
+          "version": "0.7.1",
+          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        }
+      }
     },
     "express": {
       "version": "4.6.1",
-      "from": "express@>=4.6.1 <4.7.0",
+      "from": "https://registry.npmjs.org/express/-/express-4.6.1.tgz",
       "resolved": "https://registry.npmjs.org/express/-/express-4.6.1.tgz",
       "dependencies": {
+        "accepts": {
+          "version": "1.0.7",
+          "from": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz",
+          "dependencies": {
+            "mime-types": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+            },
+            "negotiator": {
+              "version": "0.4.7",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
+            }
+          }
+        },
+        "buffer-crc32": {
+          "version": "0.2.3",
+          "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.3.tgz"
+        },
         "debug": {
           "version": "1.0.3",
-          "from": "debug@1.0.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz"
+          "from": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.6.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            }
+          }
         },
-        "mime-types": {
-          "version": "1.0.2",
-          "from": "mime-types@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+        "depd": {
+          "version": "0.3.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-0.3.0.tgz"
         },
-        "ms": {
-          "version": "0.6.2",
-          "from": "ms@0.6.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+        "escape-html": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+        },
+        "finalhandler": {
+          "version": "0.0.3",
+          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.3.tgz"
+        },
+        "media-typer": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz"
+        },
+        "methods": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
+        },
+        "parseurl": {
+          "version": "1.1.3",
+          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.3.tgz"
+        },
+        "path-to-regexp": {
+          "version": "0.1.3",
+          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
+        },
+        "proxy-addr": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz",
+          "dependencies": {
+            "ipaddr.js": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz"
+            }
+          }
+        },
+        "range-parser": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz"
+        },
+        "send": {
+          "version": "0.6.0",
+          "from": "https://registry.npmjs.org/send/-/send-0.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.6.0.tgz",
+          "dependencies": {
+            "finished": {
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
+                }
+              }
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            },
+            "ms": {
+              "version": "0.6.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.3.2",
+          "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.3.2.tgz"
         },
         "type-is": {
           "version": "1.3.2",
-          "from": "type-is@>=1.3.2 <1.4.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.3.2.tgz"
-        }
-      }
-    },
-    "extend": {
-      "version": "3.0.0",
-      "from": "extend@>=3.0.0 <3.1.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-    },
-    "extsprintf": {
-      "version": "1.0.2",
-      "from": "extsprintf@1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-    },
-    "eyes": {
-      "version": "0.1.8",
-      "from": "eyes@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
-    },
-    "finalhandler": {
-      "version": "0.0.3",
-      "from": "finalhandler@0.0.3",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.3.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "1.0.3",
-          "from": "debug@1.0.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz"
+          "from": "https://registry.npmjs.org/type-is/-/type-is-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.3.2.tgz",
+          "dependencies": {
+            "mime-types": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+            }
+          }
         },
-        "ms": {
-          "version": "0.6.2",
-          "from": "ms@0.6.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-        }
-      }
-    },
-    "finished": {
-      "version": "1.2.2",
-      "from": "finished@1.2.2",
-      "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz"
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "from": "forever-agent@>=0.6.1 <0.7.0",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-    },
-    "form-data": {
-      "version": "2.1.2",
-      "from": "form-data@>=2.1.1 <2.2.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-      "dependencies": {
-        "mime-types": {
-          "version": "2.1.15",
-          "from": "mime-types@>=2.1.12 <3.0.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
-        }
-      }
-    },
-    "fresh": {
-      "version": "0.2.2",
-      "from": "fresh@0.2.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
-    },
-    "getpass": {
-      "version": "0.1.6",
-      "from": "getpass@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-      "dependencies": {
-        "assert-plus": {
+        "vary": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz"
+        },
+        "cookie": {
+          "version": "0.1.2",
+          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+        },
+        "fresh": {
+          "version": "0.2.2",
+          "from": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
+        },
+        "cookie-signature": {
+          "version": "1.0.4",
+          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz"
+        },
+        "merge-descriptors": {
+          "version": "0.0.2",
+          "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
+        },
+        "qs": {
+          "version": "0.6.6",
+          "from": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+        },
+        "utils-merge": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         }
       }
-    },
-    "har-schema": {
-      "version": "1.0.5",
-      "from": "har-schema@>=1.0.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
-    },
-    "har-validator": {
-      "version": "4.2.1",
-      "from": "har-validator@>=4.2.1 <4.3.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
-    },
-    "hawk": {
-      "version": "3.1.3",
-      "from": "hawk@>=3.1.3 <3.2.0",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
     },
     "highland": {
-      "version": "2.10.5",
-      "from": "highland@>=2.5.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/highland/-/highland-2.10.5.tgz"
-    },
-    "hoek": {
-      "version": "2.16.3",
-      "from": "hoek@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-    },
-    "hooks-fixed": {
-      "version": "1.1.0",
-      "from": "hooks-fixed@1.1.0",
-      "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-1.1.0.tgz"
+      "version": "2.5.1",
+      "from": "https://registry.npmjs.org/highland/-/highland-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/highland/-/highland-2.5.1.tgz"
     },
     "http-as-promised": {
       "version": "1.1.0",
-      "from": "http-as-promised@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/http-as-promised/-/http-as-promised-1.1.0.tgz"
-    },
-    "http-signature": {
-      "version": "1.1.1",
-      "from": "http-signature@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
-    },
-    "i": {
-      "version": "0.3.5",
-      "from": "i@>=0.3.2 <0.4.0",
-      "resolved": "https://registry.npmjs.org/i/-/i-0.3.5.tgz"
-    },
-    "iconv-lite": {
-      "version": "0.4.3",
-      "from": "iconv-lite@0.4.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.3.tgz"
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "from": "inherits@>=2.0.1 <2.1.0",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-    },
-    "ipaddr.js": {
-      "version": "0.1.2",
-      "from": "ipaddr.js@0.1.2",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz"
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "from": "is-typedarray@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "from": "isarray@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-    },
-    "isemail": {
-      "version": "1.2.0",
-      "from": "isemail@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "from": "isstream@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-    },
-    "jodid25519": {
-      "version": "1.0.2",
-      "from": "jodid25519@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "optional": true
-    },
-    "joi": {
-      "version": "6.10.1",
-      "from": "joi@>=6.4.3 <7.0.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz"
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "from": "jsbn@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "optional": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "from": "json-schema@0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "from": "jsonify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-    },
-    "jsprim": {
-      "version": "1.4.0",
-      "from": "jsprim@>=1.2.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "from": "https://registry.npmjs.org/http-as-promised/-/http-as-promised-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-as-promised/-/http-as-promised-1.1.0.tgz",
       "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        "create-error": {
+          "version": "0.3.1",
+          "from": "https://registry.npmjs.org/create-error/-/create-error-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/create-error/-/create-error-0.3.1.tgz"
+        },
+        "request": {
+          "version": "2.75.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+            },
+            "aws4": {
+              "version": "1.5.0",
+              "from": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
+            },
+            "bl": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.11.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+            },
+            "form-data": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0",
+                  "from": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                }
+              }
+            },
+            "har-validator": {
+              "version": "2.0.6",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.15.0",
+                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "4.0.0",
+                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                },
+                "jsprim": {
+                  "version": "1.3.1",
+                  "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.10.1",
+                  "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    },
+                    "dashdash": {
+                      "version": "1.14.0",
+                      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
+                    },
+                    "getpass": {
+                      "version": "0.1.6",
+                      "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.3",
+                      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.12",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.24.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+            },
+            "qs": {
+              "version": "6.2.1",
+              "from": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.3.1",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.3",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+            }
+          }
         }
       }
     },
-    "kareem": {
-      "version": "1.0.1",
-      "from": "kareem@1.0.1",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.0.1.tgz"
+    "i": {
+      "version": "0.3.3",
+      "from": "https://registry.npmjs.org/i/-/i-0.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
     },
-    "kerberos": {
-      "version": "0.0.9",
-      "from": "kerberos@0.0.9",
-      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.9.tgz",
-      "optional": true,
+    "joi": {
+      "version": "6.10.1",
+      "from": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
       "dependencies": {
-        "nan": {
-          "version": "1.6.2",
-          "from": "nan@1.6.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz",
-          "optional": true
+        "hoek": {
+          "version": "2.16.3",
+          "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+        },
+        "topo": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
+        },
+        "isemail": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
+        },
+        "moment": {
+          "version": "2.10.6",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
         }
       }
     },
     "lodash": {
       "version": "3.7.0",
-      "from": "lodash@>=3.7.0 <3.8.0",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
     },
     "longjohn": {
-      "version": "0.2.12",
-      "from": "longjohn@>=0.2.4 <0.3.0",
-      "resolved": "https://registry.npmjs.org/longjohn/-/longjohn-0.2.12.tgz"
-    },
-    "media-typer": {
-      "version": "0.2.0",
-      "from": "media-typer@0.2.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz"
-    },
-    "merge-descriptors": {
-      "version": "0.0.2",
-      "from": "merge-descriptors@0.0.2",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
-    },
-    "methods": {
-      "version": "1.1.0",
-      "from": "methods@1.1.0",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
-    },
-    "mime": {
-      "version": "1.2.11",
-      "from": "mime@1.2.11",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-    },
-    "mime-db": {
-      "version": "1.27.0",
-      "from": "mime-db@>=1.27.0 <1.28.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
-    },
-    "mime-types": {
-      "version": "1.0.0",
-      "from": "mime-types@1.0.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.0.tgz"
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "from": "minimist@0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+      "version": "0.2.11",
+      "from": "https://registry.npmjs.org/longjohn/-/longjohn-0.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/longjohn/-/longjohn-0.2.11.tgz",
+      "dependencies": {
+        "source-map-support": {
+          "version": "0.3.2",
+          "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.2.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.32",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.0 <0.6.0",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-    },
-    "moment": {
-      "version": "2.18.1",
-      "from": "moment@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz"
+      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        }
+      }
     },
     "mongodb": {
-      "version": "2.2.25",
-      "from": "mongodb@>=2.2.25 <3.0.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.25.tgz"
-    },
-    "mongodb-core": {
-      "version": "2.1.9",
-      "from": "mongodb-core@2.1.9",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.9.tgz"
-    },
-    "mongojs": {
-      "version": "0.18.2",
-      "from": "mongojs@>=0.18.0 <0.19.0",
-      "resolved": "https://registry.npmjs.org/mongojs/-/mongojs-0.18.2.tgz",
+      "version": "1.4.39",
+      "from": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.39.tgz",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.39.tgz",
       "dependencies": {
         "bson": {
           "version": "0.2.22",
-          "from": "bson@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-0.2.22.tgz"
-        },
-        "mongodb": {
-          "version": "1.4.32",
-          "from": "mongodb@1.4.32",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.32.tgz",
+          "from": "https://registry.npmjs.org/bson/-/bson-0.2.22.tgz",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-0.2.22.tgz",
           "dependencies": {
-            "readable-stream": {
-              "version": "2.2.6",
-              "from": "readable-stream@latest",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
-              "optional": true
+            "nan": {
+              "version": "1.8.4",
+              "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+            }
+          }
+        },
+        "kerberos": {
+          "version": "0.0.11",
+          "from": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.11.tgz",
+          "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.11.tgz",
+          "dependencies": {
+            "nan": {
+              "version": "1.8.4",
+              "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
             }
           }
         },
         "readable-stream": {
-          "version": "1.1.14",
-          "from": "readable-stream@>=1.1.9 <1.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "version": "2.0.4",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
           "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
+            "process-nextick-args": {
+              "version": "1.0.5",
+              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.5.tgz"
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            }
+          }
+        }
+      }
+    },
+    "mongojs": {
+      "version": "0.18.2",
+      "from": "https://registry.npmjs.org/mongojs/-/mongojs-0.18.2.tgz",
+      "resolved": "https://registry.npmjs.org/mongojs/-/mongojs-0.18.2.tgz",
+      "dependencies": {
+        "thunky": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.13",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "mongodb": {
+          "version": "1.4.32",
+          "from": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.32.tgz",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.32.tgz",
+          "dependencies": {
+            "bson": {
+              "version": "0.2.22",
+              "from": "https://registry.npmjs.org/bson/-/bson-0.2.22.tgz",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-0.2.22.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "1.8.4",
+                  "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+                }
+              }
+            },
+            "kerberos": {
+              "version": "0.0.9",
+              "from": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.9.tgz",
+              "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.9.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "1.6.2",
+                  "from": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.0.4",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.5",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.5.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
             }
           }
         }
@@ -541,349 +936,148 @@
     },
     "mongoose": {
       "version": "4.2.8",
-      "from": "mongoose@4.2.8",
+      "from": "https://registry.npmjs.org/mongoose/-/mongoose-4.2.8.tgz",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.2.8.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "async@0.9.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "bson": {
-          "version": "0.4.23",
-          "from": "bson@>=0.4.18 <0.5.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz"
+          "version": "0.4.20",
+          "from": "https://registry.npmjs.org/bson/-/bson-0.4.20.tgz",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.20.tgz"
         },
-        "es6-promise": {
-          "version": "2.1.1",
-          "from": "es6-promise@2.1.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.1.1.tgz"
+        "hooks-fixed": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-1.1.0.tgz"
         },
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        "kareem": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/kareem/-/kareem-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.0.1.tgz"
         },
         "mongodb": {
           "version": "2.0.49",
-          "from": "mongodb@2.0.49",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.0.49.tgz"
+          "from": "https://registry.npmjs.org/mongodb/-/mongodb-2.0.49.tgz",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.0.49.tgz",
+          "dependencies": {
+            "mongodb-core": {
+              "version": "1.2.24",
+              "from": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.2.24.tgz",
+              "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.2.24.tgz"
+            },
+            "readable-stream": {
+              "version": "1.0.31",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "es6-promise": {
+              "version": "2.1.1",
+              "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.1.1.tgz"
+            },
+            "kerberos": {
+              "version": "0.0.17",
+              "from": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.17.tgz",
+              "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.17.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "2.0.9",
+                  "from": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz"
+                }
+              }
+            }
+          }
         },
-        "mongodb-core": {
-          "version": "1.2.24",
-          "from": "mongodb-core@1.2.24",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.2.24.tgz"
+        "mpath": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz"
+        },
+        "mpromise": {
+          "version": "0.5.4",
+          "from": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.4.tgz",
+          "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.4.tgz"
+        },
+        "mquery": {
+          "version": "1.6.3",
+          "from": "https://registry.npmjs.org/mquery/-/mquery-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/mquery/-/mquery-1.6.3.tgz",
+          "dependencies": {
+            "bluebird": {
+              "version": "2.9.26",
+              "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.26.tgz",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.26.tgz"
+            }
+          }
         },
         "ms": {
           "version": "0.7.1",
-          "from": "ms@0.7.1",
+          "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
-        "readable-stream": {
-          "version": "1.0.31",
-          "from": "readable-stream@1.0.31",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz"
+        "muri": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/muri/-/muri-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/muri/-/muri-1.0.0.tgz"
+        },
+        "regexp-clone": {
+          "version": "0.0.1",
+          "from": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
+        },
+        "sliced": {
+          "version": "0.0.5",
+          "from": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz"
         }
       }
-    },
-    "mpath": {
-      "version": "0.1.1",
-      "from": "mpath@0.1.1",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz"
-    },
-    "mpromise": {
-      "version": "0.5.4",
-      "from": "mpromise@0.5.4",
-      "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.4.tgz"
-    },
-    "mquery": {
-      "version": "1.6.3",
-      "from": "mquery@1.6.3",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-1.6.3.tgz",
-      "dependencies": {
-        "bluebird": {
-          "version": "2.9.26",
-          "from": "bluebird@2.9.26",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.26.tgz"
-        },
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-        }
-      }
-    },
-    "ms": {
-      "version": "0.7.2",
-      "from": "ms@0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-    },
-    "muri": {
-      "version": "1.0.0",
-      "from": "muri@1.0.0",
-      "resolved": "https://registry.npmjs.org/muri/-/muri-1.0.0.tgz"
-    },
-    "nan": {
-      "version": "1.8.4",
-      "from": "nan@>=1.8.0 <1.9.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
-    },
-    "negotiator": {
-      "version": "0.4.7",
-      "from": "negotiator@0.4.7",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
     },
     "node-uuid": {
-      "version": "1.4.8",
-      "from": "node-uuid@>=1.4.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "from": "oauth-sign@>=0.8.1 <0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-    },
-    "parseurl": {
-      "version": "1.1.3",
-      "from": "parseurl@>=1.1.3 <1.2.0",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.3.tgz"
-    },
-    "path-to-regexp": {
-      "version": "0.1.3",
-      "from": "path-to-regexp@0.1.3",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
-    },
-    "performance-now": {
-      "version": "0.2.0",
-      "from": "performance-now@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
-    },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-    },
-    "proxy-addr": {
-      "version": "1.0.1",
-      "from": "proxy-addr@1.0.1",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz"
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "from": "punycode@>=1.4.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-    },
-    "qs": {
-      "version": "0.6.6",
-      "from": "qs@0.6.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
-    },
-    "range-parser": {
-      "version": "1.0.0",
-      "from": "range-parser@1.0.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz"
-    },
-    "raw-body": {
-      "version": "1.2.2",
-      "from": "raw-body@1.2.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.2.2.tgz"
-    },
-    "readable-stream": {
-      "version": "2.1.5",
-      "from": "readable-stream@2.1.5",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
-    },
-    "regexp-clone": {
-      "version": "0.0.1",
-      "from": "regexp-clone@0.0.1",
-      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
-    },
-    "request": {
-      "version": "2.81.0",
-      "from": "request@>=2.60.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "dependencies": {
-        "mime-types": {
-          "version": "2.1.15",
-          "from": "mime-types@>=2.1.7 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
-        },
-        "qs": {
-          "version": "6.4.0",
-          "from": "qs@>=6.4.0 <6.5.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "from": "uuid@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
-        }
-      }
-    },
-    "require_optional": {
-      "version": "1.0.0",
-      "from": "require_optional@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz"
-    },
-    "resolve-from": {
-      "version": "2.0.0",
-      "from": "resolve-from@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
-    },
-    "safe-buffer": {
-      "version": "5.0.1",
-      "from": "safe-buffer@>=5.0.1 <6.0.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-    },
-    "semver": {
-      "version": "5.3.0",
-      "from": "semver@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-    },
-    "send": {
-      "version": "0.6.0",
-      "from": "send@0.6.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.6.0.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "1.0.3",
-          "from": "debug@1.0.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz"
-        },
-        "ms": {
-          "version": "0.6.2",
-          "from": "ms@0.6.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
-        }
-      }
-    },
-    "serve-static": {
-      "version": "1.3.2",
-      "from": "serve-static@>=1.3.2 <1.4.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.3.2.tgz"
-    },
-    "sliced": {
-      "version": "0.0.5",
-      "from": "sliced@0.0.5",
-      "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz"
-    },
-    "sntp": {
-      "version": "1.0.9",
-      "from": "sntp@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-    },
-    "source-map": {
-      "version": "0.5.6",
-      "from": "source-map@>=0.5.6 <0.6.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-    },
-    "source-map-support": {
-      "version": "0.4.14",
-      "from": "source-map-support@>=0.3.2 <=1.0.0",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz"
-    },
-    "sshpk": {
-      "version": "1.11.0",
-      "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-        }
-      }
-    },
-    "stack-trace": {
-      "version": "0.0.9",
-      "from": "stack-trace@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "from": "string_decoder@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "from": "stringstream@>=0.0.4 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+      "version": "1.4.7",
+      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "throttle-function": {
       "version": "0.1.0",
-      "from": "throttle-function@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/throttle-function/-/throttle-function-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/throttle-function/-/throttle-function-0.1.0.tgz"
-    },
-    "thunky": {
-      "version": "0.1.0",
-      "from": "thunky@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz"
     },
     "tiny-sse": {
       "version": "0.0.0",
-      "from": "git+https://github.com/agco/node-tiny-sse.git",
-      "resolved": "git+https://github.com/agco/node-tiny-sse.git#5db54ad0054b31f2253ffaf4776873b7f6758b8c"
-    },
-    "topo": {
-      "version": "1.1.0",
-      "from": "topo@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
-    },
-    "tough-cookie": {
-      "version": "2.3.2",
-      "from": "tough-cookie@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "from": "tunnel-agent@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "from": "tweetnacl@>=0.14.0 <0.15.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "optional": true
-    },
-    "type-is": {
-      "version": "1.3.1",
-      "from": "type-is@1.3.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.3.1.tgz"
+      "from": "https://registry.npmjs.org/tiny-sse/-/tiny-sse-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tiny-sse/-/tiny-sse-0.0.0.tgz"
     },
     "underscore.string": {
       "version": "2.4.0",
-      "from": "underscore.string@>=2.4.0 <3.0.0",
+      "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-    },
-    "utils-merge": {
-      "version": "1.0.0",
-      "from": "utils-merge@1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-    },
-    "vary": {
-      "version": "0.1.0",
-      "from": "vary@0.1.0",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz"
-    },
-    "verror": {
-      "version": "1.3.6",
-      "from": "verror@1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-    },
-    "winston": {
-      "version": "2.3.1",
-      "from": "winston@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lodash": "~3.7.0",
     "longjohn": "^0.2.4",
     "mkdirp": "~0.5.0",
-    "mongodb": "^2.2.25",
+    "mongodb": "^1.4.26",
     "mongojs": "^0.18.0",
     "mongoose": "4.2.8",
     "node-uuid": "^1.4.3",


### PR DESCRIPTION
Seems to break fuse-telemetry
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/agco/harvesterjs/pull/211?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/agco/harvesterjs/pull/211'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/agco/harvesterjs/211)
<!-- Reviewable:end -->
