### PR TITLE
Improve events reader

### DIFF
--- a/lib/events-reader.js
+++ b/lib/events-reader.js
@@ -20,13 +20,6 @@ module.exports = function(harvesterApp) {
       d: 'delete',
     };
 
-    mongoose
-      .connect(oplogMongodbUri, {
-        poolSize: 10,
-        socketOptions: { keepAlive: 250 },
-      })
-      .then(() => console.log('EventsReader connected to oplog'))
-      .catch(err => console.log(err));
 
     var docStream = hl();
 
@@ -334,13 +327,22 @@ module.exports = function(harvesterApp) {
       })
       .parallel(100);
 
-    return new Promise(function(resolve) {
+    return new Promise(function(resolve, reject) {
       if (!harvesterApp.adapter.model('checkpoint')) {
         harvesterApp.resource('checkpoint', {
           ts: Joi.any(),
         });
       }
-      resolve(EventsReader);
+      mongoose
+        .connect(oplogMongodbUri, {
+          poolSize: 10,
+          socketOptions: { keepAlive: 250 },
+        })
+        .then(() => {
+          debug('EventsReader connected to oplog');
+          resolve(EventsReader);
+        })
+        .catch(err => reject(err));
     });
   };
 };

--- a/lib/events-reader.js
+++ b/lib/events-reader.js
@@ -3,12 +3,12 @@ let _ = require('lodash'),
   inflect = require('i')(),
   Promise = require('bluebird'),
   debug = require('debug')('events-reader'),
-  BSON = require('mongodb').BSONPure,
   hl = require('highland'),
   checkpointWriter = require('./events-reader-checkpoint-writer'),
   Joi = require('joi');
 
 const mongoose = require('mongoose');
+const Timestamp = mongoose.mongo.Timestamp;
 
 module.exports = function(harvesterApp) {
   return function(oplogMongodbUri) {
@@ -45,7 +45,7 @@ module.exports = function(harvesterApp) {
             debug('checkpoint missing, creating... ');
             harvesterApp.adapter
               .create('checkpoint', {
-                ts: BSON.Timestamp(0, Date.now() / 1000),
+                ts: Timestamp(0, Date.now() / 1000),
               })
               .then(function() {
                 // If a stop was requested just before here, then tailing would no longer be correct!

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "longjohn": "^0.2.4",
     "mkdirp": "~0.5.0",
     "mongodb": "^2.2.26",
-    "mongojs": "^0.18.0",
     "mongoose": "^4.9.9",
     "node-uuid": "^1.4.3",
     "throttle-function": "^0.1.0",

--- a/test/events-reader.spec.js
+++ b/test/events-reader.spec.js
@@ -233,6 +233,41 @@ describe('onChange callback, event capture and at-least-once delivery semantics'
       });
 
       describe('When a new post is added', function() {
+        it('should skip as there is only a change handler fn defined on delete', function(
+          done
+        ) {
+          var that = this;
+          that.timeout(100000);
+
+          that.eventsReader.skip = function(dfd, doc) {
+            // todo fix this
+
+            var regex = new RegExp('.*\\.posts', 'i');
+            if (regex.test(doc.ns)) {
+
+              dfd.resolve();
+              done();
+            }
+          };
+
+          that.chaiExpress
+            .post('/posts')
+            .send({
+              posts: [
+                {
+                  title: 'a simple topic',
+                },
+              ],
+            })
+            .catch(function(err) {
+              console.trace(err);
+              done(err);
+            });
+
+          that.checkpointCreated.then(function() {
+            that.eventsReader.tail();
+          });
+        });
       });
 
       describe('When that abuse report API resource responds with a 201 created', function() {

--- a/test/events-reader.spec.js
+++ b/test/events-reader.spec.js
@@ -233,41 +233,6 @@ describe('onChange callback, event capture and at-least-once delivery semantics'
       });
 
       describe('When a new post is added', function() {
-        xit('should skip as there is only a change handler fn defined on delete', function(
-          done
-        ) {
-          var that = this;
-          that.timeout(100000);
-
-          that.eventsReader.skip = function(dfd, doc) {
-            // todo fix this
-
-            var regex = new RegExp('.*\\.posts', 'i');
-            if (regex.test(doc.ns)) {
-
-              dfd.resolve();
-              done();
-            }
-          };
-
-          that.chaiExpress
-            .post('/posts')
-            .send({
-              posts: [
-                {
-                  title: 'a simple topic',
-                },
-              ],
-            })
-            .catch(function(err) {
-              console.trace(err);
-              done(err);
-            });
-
-          that.checkpointCreated.then(function() {
-            that.eventsReader.tail();
-          });
-        });
       });
 
       describe('When that abuse report API resource responds with a 201 created', function() {

--- a/test/events-reader.spec.js
+++ b/test/events-reader.spec.js
@@ -176,7 +176,6 @@ describe('onChange callback, event capture and at-least-once delivery semantics'
           const oplog = mongoose.connection.db.collection('oplog.rs');
           const Timestamp = mongoose.mongo.Timestamp;
 
-
           return new Promise(function(resolve, reject) {
             return oplog 
               .find({})
@@ -229,44 +228,6 @@ describe('onChange callback, event capture and at-least-once delivery semantics'
               done();
             })
             .catch(done);
-        });
-      });
-
-      describe('When a new post is added', function() {
-        it('should skip as there is only a change handler fn defined on delete', function(
-          done
-        ) {
-          var that = this;
-          that.timeout(100000);
-
-          that.eventsReader.skip = function(dfd, doc) {
-            // todo fix this
-
-            var regex = new RegExp('.*\\.posts', 'i');
-            if (regex.test(doc.ns)) {
-
-              dfd.resolve();
-              done();
-            }
-          };
-
-          that.chaiExpress
-            .post('/posts')
-            .send({
-              posts: [
-                {
-                  title: 'a simple topic',
-                },
-              ],
-            })
-            .catch(function(err) {
-              console.trace(err);
-              done(err);
-            });
-
-          that.checkpointCreated.then(function() {
-            that.eventsReader.tail();
-          });
         });
       });
 
@@ -399,7 +360,6 @@ describe('onChange callback, event capture and at-least-once delivery semantics'
     that.timeout(100000);
 
     mockReports();
-
 
     that.checkpointCreated.then(function() {
       setTimeout(that.eventsReader.tail.bind(that.eventsReader), 500);


### PR DESCRIPTION
Since the refactoring to replace mongojs with mongoose we weren't risking async race conditions problems, because mongojs was creating a connection at events reader factory function synchronously.

Now we have to wait for the connection to be created sucessfully before exposing EventsReader prototype for clients.

- [x] Remove mongojs
- [x] Refactor events reader to use mongoose