### PR TITLE
[Do not merge][SSE] producing message from oplog to kafka and from kafka to SSE

### DIFF
--- a/lib/events-reader.js
+++ b/lib/events-reader.js
@@ -5,13 +5,7 @@ let _ = require('lodash'),
   debug = require('debug')('events-reader'),
   hl = require('highland'),
   checkpointWriter = require('./events-reader-checkpoint-writer'),
-  Joi = require('joi'),
-  Kafka = require('no-kafka'),
-  brokers = "localhost:9092";
-
-const producer = new Kafka.Producer({
-  connectionString: brokers,
-});
+  Joi = require('joi');
 
 const mongoose = require('mongoose');
 const Timestamp = mongoose.mongo.Timestamp;
@@ -80,22 +74,6 @@ module.exports = function(harvesterApp) {
       var doc;
       doc = that.stream.read();
 
-      // If it is a doc add to kafka
-      if(doc !== null && (!doc.ns.includes('checkpoint'))) {
-        producer.init().then(function(){
-          return producer.send({
-            topic: 'darksouls',
-            partition: 0,
-            message: {
-              value: JSON.stringify(doc)
-            }
-          });
-        })
-        .then(function (result) {
-          console.log('>>> producer sent message');
-        });
-      }
-
       var promises = that.processDocHandlers(doc);
 
       Promise.all(promises)
@@ -112,8 +90,7 @@ module.exports = function(harvesterApp) {
         query = {},
         options = {
           tailable: true,
-          awaitData: true,
-          timeout: false,
+          awaitData: true
         };
 
       time = { $gt: since };

--- a/lib/events-reader.js
+++ b/lib/events-reader.js
@@ -5,7 +5,13 @@ let _ = require('lodash'),
   debug = require('debug')('events-reader'),
   hl = require('highland'),
   checkpointWriter = require('./events-reader-checkpoint-writer'),
-  Joi = require('joi');
+  Joi = require('joi'),
+  Kafka = require('no-kafka'),
+  brokers = "localhost:9092";
+
+const producer = new Kafka.Producer({
+  connectionString: brokers,
+});
 
 const mongoose = require('mongoose');
 const Timestamp = mongoose.mongo.Timestamp;
@@ -73,6 +79,22 @@ module.exports = function(harvesterApp) {
 
       var doc;
       doc = that.stream.read();
+
+      // If it is a doc add to kafka
+      if(doc !== null && (!doc.ns.includes('checkpoint'))) {
+        producer.init().then(function(){
+          return producer.send({
+            topic: 'darksouls',
+            partition: 0,
+            message: {
+              value: JSON.stringify(doc)
+            }
+          });
+        })
+        .then(function (result) {
+          console.log('>>> producer sent message');
+        });
+      }
 
       var promises = that.processDocHandlers(doc);
 

--- a/lib/harvester.js
+++ b/lib/harvester.js
@@ -12,6 +12,8 @@ let route = require('./route');
 
 let sendError = require('./send-error');
 
+const KafkaProducer = require('./kafka-producer');
+
 /* !
  * The Harvester object.
  */
@@ -100,6 +102,7 @@ Harvester.prototype._init = function(options) {
     }
   }
   this.options = options;
+  const kafkaProducer = KafkaProducer(options);
 
   // Create the underlying express framework instance.
   this.router = express();

--- a/lib/kafka-producer.js
+++ b/lib/kafka-producer.js
@@ -1,0 +1,56 @@
+const Kafka = require('no-kafka');
+const mongoose = require('mongoose');
+
+const brokers = "localhost:9092";
+
+const producer = new Kafka.Producer({
+  connectionString: brokers,
+});
+
+const tailOplog = (db) => {
+  const options = {
+    tailable: true,
+    awaitdata: true
+  };
+
+  const stream = db.collection('oplog.rs').find({}, options);
+
+  stream.on('data', onData)
+    .on('error', () => {
+      console.log('Error oplog stream');
+    })
+    .on('close', () => {
+      console.log('Closing oplog stream')
+    });
+};
+
+const KafkaProducer = (options) => {
+  const db = mongoose.createConnection(options.oplogConnectionString, {
+    poolSize: 10,
+    socketOptions: { keepAlive: 250  },
+  })
+
+  db.on('open', (err) => {
+    tailOplog(db);
+  });
+};
+
+const onData = (doc) => {
+  if (!doc.ns.includes('author')) {
+    return;
+  }
+
+  return producer.init().then(function(){
+    return producer.send({
+      topic: 'authors',
+      partition: 0,
+      message: {
+        value: doc
+      }
+    });
+  })
+  .then(() =>  console.log('>>> producer sent message'));
+};
+
+
+module.exports = KafkaProducer;

--- a/lib/kafka-producer.js
+++ b/lib/kafka-producer.js
@@ -13,6 +13,7 @@ const tailOplog = (db) => {
     awaitdata: true
   };
 
+  // This is incomplete because we need to query the oplog for the last events
   const stream = db.collection('oplog.rs').find({}, options);
 
   stream.on('data', onData)
@@ -45,7 +46,7 @@ const onData = (doc) => {
       topic: 'authors',
       partition: 0,
       message: {
-        value: doc
+        value: JSON.stringify(doc)
       }
     });
   })

--- a/lib/sse.js
+++ b/lib/sse.js
@@ -8,6 +8,29 @@ let Promise = require('bluebird');
 let hl = require('highland');
 let JSONAPI_Error = require('./jsonapi-error');
 
+const Kafka = require('no-kafka');
+const brokers = "localhost:9092";
+
+const consumer = new Kafka.GroupConsumer({
+  connectionString: brokers,
+});
+
+const dataHandler = (req, res, harvesterInstance) => (messageSet, topic, partition) => {
+  return Promise.all(messageSet.map((m) => {
+    const doc = JSON.parse(m.message.value);
+    console.log('>>>> consumed from kafka >>', doc);
+
+    const eventName = inflect.pluralize('author') + '_' + doc.op;
+    //const id = doc.ts.getHighBits() + '_' + doc.ts.getLowBits();
+    const data = harvesterInstance.getData('author', doc);
+
+    tinySSE.send({ event: eventName, data: data })(req, res);
+    // commit offset
+    return consumer.commitOffset({topic: topic, partition: partition, offset: m.offset, metadata: 'optional'});
+  }));
+};
+
+
 /*
 Usage:
 ======================================
@@ -126,7 +149,19 @@ SSE.prototype.requestValidationMiddleware = function(req, res, next) {
   next();
 };
 
-SSE.prototype.handler = function(req, res) {
+SSE.prototype.handler = function (req, res) {
+
+  const strategies = [{
+    subscriptions: ['authors'],
+    handler: dataHandler(req, res, this)
+  }];
+
+  consumer.init(strategies);
+
+  next();
+};
+
+SSE.prototype.handler2 = function(req, res) {
   var oplogConnectionString = this.options.oplogConnectionString || '';
 
   var that = this;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mkdirp": "~0.5.0",
     "mongodb": "^2.2.26",
     "mongoose": "^4.9.9",
+    "no-kafka": "^3.1.6",
     "node-uuid": "^1.4.3",
     "throttle-function": "^0.1.0",
     "tiny-sse": "git+https://github.com/agco/node-tiny-sse.git",


### PR DESCRIPTION
This Pull Request is intended to document the experiments we have made streaming events from the oplog to Kafka and from Kafka to SSE.

**Hypothesis**:
We believe that by adding kafka to harvesterjs sse implementation
Will result in a decreased amount of queries to the oplog
We will have confidence to proceed when we see a decreased amount of connections to the oplog for a single resource


**Results**:

- **[Blocker]** It would be necessary to have a mechanism in place to figure out what was the last thing transferred from the oplog to a particular Kafka topic for a specific client taking the last-event-id into consideration. This alone invalidates the Hypothesis. 

- **[Blocker]** There is no way to create topic programmatically on Kafka. Documentation [no-kafka](https://github.com/oleksiyk/kafka#topic-creation).

- Harvesterjs based apps would have to have a Kafka infrastructure in place.

- Kafka slows down the SSE process by several seconds.

- This is not the recommended use of Kafka (the same app producing and consuming from a particular topic). Kafka is meant for distributed systems, the main benefits of having Kafka as a central queue would be lost with this approach.